### PR TITLE
builder: Display stringified errno so we know _why_ a copy failed

### DIFF
--- a/tools/builder/file_cp.c
+++ b/tools/builder/file_cp.c
@@ -1,6 +1,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
+#include <err.h>
 
 
 /*
@@ -58,7 +59,7 @@ int file_cp(const char *to, const char *from)
     }
 
   out_error:
-    printf("Error copying %s to %s\n", from, to);
+    warn("Error copying %s to %s", from, to);
     saved_errno = errno;
 
     close(fd_from);


### PR DESCRIPTION
Call warn() rather than printf() so the reason file_cp fails makes it
into the log.
