### PR TITLE
machine-create: /etc/nodename must be newline terminated

### DIFF
--- a/src/machine/machine-create.js
+++ b/src/machine/machine-create.js
@@ -873,7 +873,7 @@ function writeZoneconfig(payload, callback)
 
     debug('writing extra files to zone root');
     fs.writeFileSync(payload.zone_path + '/root/etc/nodename',
-        payload.hostname);
+        payload.hostname + '\n');
     fs.writeFileSync(payload.zone_path +
         '/root/var/svc/log/system-zoneinit:default.log', '');
 


### PR DESCRIPTION
It turns out that svc:/system/identity:node is only willing to deal with a newline-terminated nodename file.  So we forcefully append a newline.

This is because, while `cat` would deal with this just fine, the network SMF methods use a function, `shcat`

``` sh
#
# shcat file
#   Simulates cat in sh so it doesn't need to be on the root filesystem.
#
shcat() {
        while [ $# -ge 1 ]; do
                while read i; do
                        echo "$i"
                done < $1
                shift
        done
}
```

Which doesn't.  Either that, or I've somehow gone crazy.
