### PR TITLE
tools/get_status: only look at ur-agent if it exists, get kvm and kvm-cmd statuses

### DIFF
--- a/tools/get_status
+++ b/tools/get_status
@@ -31,5 +31,7 @@ echo "["
 echo "    { \"repo\": \"illumos-live\", $(get_status ${ROOT}) }"
 echo "  , { \"repo\": \"illumos-extra\", $(get_status ${ROOT}/projects/illumos-extra) }"
 echo "  , { \"repo\": \"illumos-joyent\", $(get_status ${ROOT}/projects/illumos) }"
-echo "  , { \"repo\": \"ur-agent\", $(get_status ${ROOT}/projects/local/ur-agent) }"
+if [[ -d ${ROOT}/projects/local/ur-agent ]]; then
+    echo "  , { \"repo\": \"ur-agent\", $(get_status ${ROOT}/projects/local/ur-agent) }"
+fi
 echo "]"

--- a/tools/get_status
+++ b/tools/get_status
@@ -31,6 +31,8 @@ echo "["
 echo "    { \"repo\": \"illumos-live\", $(get_status ${ROOT}) }"
 echo "  , { \"repo\": \"illumos-extra\", $(get_status ${ROOT}/projects/illumos-extra) }"
 echo "  , { \"repo\": \"illumos-joyent\", $(get_status ${ROOT}/projects/illumos) }"
+echo "  , { \"repo\": \"illumos-kvm\", $(get_status ${ROOT}/projects/local/kvm) }"
+echo "  , { \"repo\": \"illumos-kvm-cmd\", $(get_status ${ROOT}/projects/local/kvm-cmd) }"
 if [[ -d ${ROOT}/projects/local/ur-agent ]]; then
     echo "  , { \"repo\": \"ur-agent\", $(get_status ${ROOT}/projects/local/ur-agent) }"
 fi


### PR DESCRIPTION
Mostly, only get the git status of ur-agent if one actually exists (which it won't outside of, I presume, Joyent), thus gagging a warning from 'gmake live'.

While here, also pull the status of illumos-kvm and illumos-kvm-cmd, since they're there and it seemed worth doing.
