### PR TITLE
dns: re-add /etc/nsswitch.conf.

### DIFF
--- a/overlay/generic/etc/nsswitch.conf
+++ b/overlay/generic/etc/nsswitch.conf
@@ -1,0 +1,54 @@
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# /etc/nsswitch.conf:
+#
+# "hosts:" and "services:" in this file are used only if the
+# /etc/netconfig file has a "-" for nametoaddr_libs of "inet" transports.
+
+passwd:     files
+group:      files
+hosts:      files mdns dns
+ipnodes:    files mdns dns
+networks:   files
+protocols:  files
+rpc:        files
+ethers:     files
+netmasks:   files
+bootparams: files
+publickey:  files
+# At present there isn't a 'files' backend for netgroup;  the system will 
+#   figure it out pretty quickly, and won't use netgroups at all.
+netgroup:   files
+automount:  files
+aliases:    files
+services:   files
+printers:   user files
+
+auth_attr:  files
+prof_attr:  files
+project:    files
+
+tnrhtp:     files
+tnrhdb:     files

--- a/overlay/generic/manifest
+++ b/overlay/generic/manifest
@@ -19,6 +19,7 @@ f etc/motd 0644 root sys
 d etc/notices 0755 root sys
 f etc/notices/COPYRIGHT 0444 root sys
 f etc/name_to_major 0644 root sys
+f etc/nsswitch.conf 0644 root sys
 f etc/passwd 0644 root sys
 f etc/release 0444 root sys
 f etc/nodename 0644 root root


### PR DESCRIPTION
It appears that it got "lost" during split between overlays.
