### PR TITLE
Makefile: Explicitly use gtar, for -O

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ manifest:
 ifeq ($(EXTRA_TARBALL),)
 		gmake DESTDIR=$(MPROTO) DESTNAME=illumos-extra.manifest -C projects/illumos-extra manifest
 else
-		tar -Ozxf $(EXTRA_TARBALL) manifest > $(MPROTO)/illumos-extra.manifest
+		gtar -Ozxf $(EXTRA_TARBALL) manifest > $(MPROTO)/illumos-extra.manifest
 endif
 	[ ! -d projects/local ] || for dir in $(LOCAL_SUBDIRS); do \
 	cd $(ROOT)/projects/local/$${dir}; \


### PR DESCRIPTION
Illumos tar doesn't support `-O`, explicitly call `gtar` to be sure we always get GNU tar.

John tells me that this should work even while building under SmartOS, but I've not actually tried that to confirm.
