### PR TITLE
cpp: Act somewhat more like devpro cpp(1), report errors legibly

### DIFF
--- a/src_addon/cpp/cpp.c
+++ b/src_addon/cpp/cpp.c
@@ -1090,32 +1090,42 @@ ppsym(s) char *s; {/* kluge */
 	cinit=SALT; *savch++=SALT; sp=stsym(s); --sp->name; cinit=0; return(sp);
 }
 
+void
+verror(char *fmt, va_list args)
+{
+	if (fnames[ifno][0])
+		fprintf(stderr, "%s: ", fnames[ifno]);
+	fprintf(stderr, "%d: ",lineno[ifno]);
+
+	(void)vfprintf(stderr, fmt, args);
+	fputc('\n', stderr);
+}
+
 /* VARARGS1 */
 void
 pperror(char *fmt, ...)
 {
 	va_list	args;
 
-	if (fnames[ifno][0])
-		fprintf(stderr, "%s: ", fnames[ifno]);
-	fprintf(stderr, "%d: ",lineno[ifno]);
-
 	va_start(args);
-	(void)fprintf(stderr, "%r\n", fmt, args);
+	verror(fmt, args);
 	va_end(args);
+
 	++exfail;
 }
 
+/* VARARGS1 */
 void
 yyerror(char *fmt, ...)
 {
 	va_list	args;
 
 	va_start(args);
-	pperror("%r", fmt, args);
+	verror(fmt, args);
 	va_end(args);
 }
 
+/* VARARGS1 */
 static void
 ppwarn(char *fmt, ...)
 {
@@ -1124,7 +1134,7 @@ ppwarn(char *fmt, ...)
 	exfail = -1;
 
 	va_start(args);
-	pperror("%r", fmt, args);
+	verror(fmt, args);
 	va_end(args);
 
 	exfail = fail;


### PR DESCRIPTION
DevPro `cpp` defines the symbol which causes our `stdarg.h` to do protocol for variadic functions in the studio fashion.  Without this (or the GNU equivalent), we #error out of that header, and `dtrace -C` that in any way ends up including `sys/va_impl.h` is broken.  It is safer to act like Studio in this case both because of history, and because acting GNU-ishly could also trigger the use of **attribute**, and further confuse DTrace.

While doing this, also fix error reporting such that errors and warnings are actually reported.  Previously it used a printf `%r` specifier which we (and anyone else I found in a very quick search) appear to lack, so errors were not, in fact, reported.

Both of these in combination are issue #25, though the change for stdarg is the only one which truly matters.

I've tested this by preprocessing the files in that issue from @alasdairrr and by run the specific phelper.d through dtrace in the same manner as the python build, but haven't actually done the full python build under SmartOS and with this cpp, 
