### PR TITLE
VM: Don't treat multiple dhcp interfaces as conflicts

### DIFF
--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -1467,7 +1467,8 @@ function lookupConflicts(macs, ips, callback) {
                     return cb(error);
                 }
                 for (ip in ips) {
-                    if (matcher(obj, {'nics.*.ip': ips[ip]})) {
+                    if (ips[ip] !== 'dhcp' &&
+                        matcher(obj, {'nics.*.ip': ips[ip]})) {
                         VM.log('ERROR', 'Found conflict: ' + obj.uuid +
                             ' already has IP ' + ips[ip]);
                         conflict = true;


### PR DESCRIPTION
Multiple ip entries of 'dhcp' are not actual conflicts, skip them when
checking for IP conflicts.

There may be a better way to solve this, and I'm not entirely certain ip fields are normalized such that straight string comparison is sufficient.
