### PR TITLE
VM: Use logical not binary & for logical affect

### DIFF
--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -3535,7 +3535,7 @@ function applyUpdates(oldobj, newobj, payload, callback)
                     factor = 1;
                 }
 
-                if (newobj.brand === 'joyent' & payload.hasOwnProperty(prop)) {
+                if (newobj.brand === 'joyent' && payload.hasOwnProperty(prop)) {
                     setRctl(newobj.zonename, rctl, Number(payload[prop]) * factor,
                         function(err)
                         {


### PR DESCRIPTION
Looks like a typo `&` v. `&&`.  I found this when merging with some changes of mine to support an extra zone brand, so I haven't hit this in practice, and thus can't entirely say I've tested this sufficiently.
