### PR TITLE
builder: actually set the permission of directories

### DIFF
--- a/tools/builder/builder.c
+++ b/tools/builder/builder.c
@@ -190,7 +190,7 @@ int main(int argc, char *argv[])
   }
 
   /* scan through the manifest once each for each type of entry, in order */
-  while (pass < 5) {
+  while (pass < 6) {
     file = fopen(manifest, "r");
     if (file != NULL) {
        while(fgets(line, MAX_LINE_LEN, file) != NULL) {
@@ -201,6 +201,13 @@ int main(int argc, char *argv[])
              if (args_found == 5) {
                if (pass == 1) {
                  handle_dir(target, mode, user, group);
+               } else if (pass == 5) { /* Set permissions last, in case read-only */
+                   mode_t m;
+                   m = str_to_mode(mode);
+                   if (chmod(target, m) != 0) {
+                       perror("chmod()");
+                       exit(1);
+                   }
                }
              } else {
                printf("Wrong number of arguments for directory on line[%d]: %s\n", lineno, line);


### PR DESCRIPTION
Directories were being left at 0755, which is right 99% of the time, so
seems to have escaped.  It's wrong, however, for `/tmp`, and `/var/tmp`.

Add a 5th pass to `builder` (lest a read-only directory need contents),
and set directories permissions.

This is not as graceful as it could -- or should -- be, but then again neither is `builder`.

I've tested this lightly, to the extent that I needed a valid `/var/tmp` in the GZ and didn't have one, and now do, and I spot-checked `/tmp` also, nothing else.
