### PR TITLE
Use callback to make sure we are listening before getting server.address()

### DIFF
--- a/src/vm/sbin/vmadmd.js
+++ b/src/vm/sbin/vmadmd.js
@@ -113,13 +113,14 @@ function spawnVNC(vmobj)
     VM.log('INFO', 'spawning VNC listener for ' + vmobj.uuid + ' on ' +
         SDC.sysinfo.admin_ip);
     // Listen on a random port on admin_ip
-    server.listen(0, SDC.sysinfo.admin_ip);
-    addr = server.address();
+    server.listen(0, SDC.sysinfo.admin_ip, function () {
+        addr = server.address();
 
-    VNC[vmobj.uuid] = {'host': SDC.sysinfo.admin_ip, 'port': addr.port,
-        'display': (addr.port - 5900), 'server': server};
+        VNC[vmobj.uuid] = {'host': SDC.sysinfo.admin_ip, 'port': addr.port,
+            'display': (addr.port - 5900), 'server': server};
 
-    VM.log('DEBUG', 'VNC details for ' + vmobj.uuid + ':' + VNC[vmobj.uuid]);
+        VM.log('DEBUG', 'VNC details for ' + vmobj.uuid + ':' + VNC[vmobj.uuid]);
+    });
 }
 
 function clearVNC(uuid)


### PR DESCRIPTION
I have done some testing with getting Node.js 0.6.x into SmartOS, and it seems to experience a race condition where `server.address()` is not defined when it is assigned to `addr`. The solution to this is to wrap it in a callback which is run when `server.listen()` has been set up.
