### PR TITLE
Cleanup of zfs.js

### DIFF
--- a/src/ds/node_modules/zfs.js
+++ b/src/ds/node_modules/zfs.js
@@ -2,7 +2,7 @@
 
 # ZFS Library
 
-This is an alternative library for managing ZFS using spawned 
+This is an alternative library for managing ZFS using spawned
 processes. It remains less than ideal.
 
 Sizes are normalized in MB (MegaBytes or 1024*1024)
@@ -17,7 +17,7 @@ Sizes are normalized in MB (MegaBytes or 1024*1024)
 * Delete a dataset (option recuursively)
 * Get a dataset and its children as an array
 
-### To Implement: 
+### To Implement:
 
 * Rollback a Snapshot
 
@@ -58,7 +58,7 @@ var QUERY_PROPERTIES = [
   'volblocksize',
   'dsadm:uuid',
   'dsadm:urn'
-];  
+];
 
 var VOL_PROPERTIES = [
   'name',
@@ -98,7 +98,7 @@ var FS_PROPERTIES = [
   'usedbychildren',
   'dsadm:uuid',
   'dsadm:urn'
-];  
+];
 
 var ERR_LIST    = 10;
 var ERR_SET     = 11;
@@ -107,28 +107,29 @@ var ERR_GET     = 13;
 var ERR_EXIST   = 20;
 var ERR_RENAME  = 21;
 var ERR_SNAP    = 22;
-var ERR_DESTROY = 23
+var ERR_DESTROY = 23;
 
 var newError = function(code, message) {
   assert.ok(code);
   assert.ok(message);
   return JSON.stringify({error: {code: code, message: message}});
-}
+};
 
 function toMB(value) {
-  return Math.ceil(value / 1048676) // 1024*1024
+  return Math.ceil(value / 1048676); // 1024*1024
 }
 
 function toMiB(value) {
-  return Math.ceil(value / 1000000) // 1000*1000
+  return Math.ceil(value / 1000000); // 1000*1000
 }
 
-_formatPoolProperty = function(prop, val) {
+var _formatPoolProperty = function(prop, val) {
   assert.ok(prop);
   assert.ok(val);
  
-  if (val === "-") 
+  if (val === "-") {
     return [prop, null];
+  }
 
   switch (prop) {
     case "size":
@@ -142,50 +143,53 @@ _formatPoolProperty = function(prop, val) {
       break;
   }
   return [prop, val];
-}
+};
 
-_formatRecord = function(record) {
+var _formatRecord = function(record) {
   assert.ok(record);
 
   var result;
 
-  format = function(record, properties) {
+  var format = function(record, properties) {
     assert.ok(record);
     assert.ok(properties);
 
     var r = {};
-    for (i in properties) {
-      var p = properties[i];
-      var v = record[p];
-      r[p] = _formatProperty(p, v)[1];
+    for (var i in properties) {
+      if (properties.hasOwnProperty(i)) {
+        var p = properties[i];
+        var v = record[p];
+        r[p] = _formatProperty(p, v)[1];
+      }
     }
     return r;
-  }
+  };
 
   switch(record.type) {
     case "volume":
-      result = format(record, VOL_PROPERTIES); 
+      result = format(record, VOL_PROPERTIES);
       break;
     case "snapshot":
-      result = format(record, SNAP_PROPERTIES); 
+      result = format(record, SNAP_PROPERTIES);
       break;
     case "filesystem":
-      result = format(record, FS_PROPERTIES); 
+      result = format(record, FS_PROPERTIES);
       break;
   }
 
   return result;
-}
+};
 
-_formatProperty = function(prop, val) {
+var _formatProperty = function(prop, val) {
   assert.ok(prop);
-  assert.ok(val); 
+  assert.ok(val);
 
-  if (val === "-")
+  if (val === "-") {
     return [prop, null];
+  }
 
   switch (prop) {
-    case "sdc:dataset": 
+    case "sdc:dataset":
       if (val === null) {
         val = false;
       } else {
@@ -217,7 +221,7 @@ _formatProperty = function(prop, val) {
       val = toMB(val);
       break;
     case "volblocksize":
-      val = parseInt(val);
+      val = parseInt(val, 10);
       break;
     case "creation":
       var d = (val * 1000);
@@ -225,9 +229,9 @@ _formatProperty = function(prop, val) {
       break;
   }
   return [prop, val];
-}
+};
 
-setFilter = {
+var setFilter = {
   dataset: function(ele, idx, arr) {
     return (ele['dsadm:uuid']);
   },
@@ -242,11 +246,11 @@ setFilter = {
   },
   filesystem: function(ele, idx, arr) {
     return (ele.type === 'filesystem');
-  },
+  }
 
-}
+};
 
-get = function(name, callback) {
+var get = function(name, callback) {
   assert.ok(name);
   assert.ok(callback);
 
@@ -256,12 +260,12 @@ get = function(name, callback) {
   args.push(QUERY_PROPERTIES.join(','));
   args.push(name);
 
-  zfs = spawn(ZFS, args);
+  var zfs = spawn(ZFS, args);
 
-  parseData = function() {
+  var parseData = function() {
     var dataset = {};
-    var line, prop, val
-    lines = data.split(/\n/);
+    var line, prop, val;
+    var lines = data.split(/\n/);
     for (var i=0; i<lines.length; i++) {
       line = lines[i].split(/\t/);
       prop = line[0];
@@ -271,7 +275,7 @@ get = function(name, callback) {
 
     }
     callback(error, _formatRecord(dataset));
-  }
+  };
 
   zfs.stdout.on('data', function(chunk) {
     data = data + chunk.toString();
@@ -281,9 +285,9 @@ get = function(name, callback) {
     parseData();
   });
   
-}
+};
 
-getRecursive = function(name, callback) {
+var getRecursive = function(name, callback) {
   assert.ok(name);
   assert.ok(callback);
 
@@ -293,9 +297,9 @@ getRecursive = function(name, callback) {
   args.push(QUERY_PROPERTIES.join(','));
   args.push(name);
   
-  zfs = spawn(ZFS, args);
+  var zfs = spawn(ZFS, args);
 
-  parseData = function() {
+  var parseData = function() {
     var old, name, prop, val;
     var datasets = [];
     var dataset = {};
@@ -303,27 +307,29 @@ getRecursive = function(name, callback) {
     
     for (var i=0; i<lines.length; i++) {
       var line = lines[i].split(/\t/);
-      if (line.length === 1) { 
+      if (line.length === 1) {
         datasets.push(_formatRecord(dataset));
         break;
-      } 
+      }
       
       name = line[0];
       prop = line[1];
       val = line[2];
 
-      if (old == name) {
+      if (old === name) {
         dataset[prop] = val;
       }
       else {
         old = name;
-        if (dataset.name) datasets.push(_formatRecord(dataset));
+        if (dataset.name) {
+          datasets.push(_formatRecord(dataset));
+        }
         dataset = {name: name};
         dataset[prop] = val;
       }
     }
     callback(error, datasets);
-  }
+  };
   
   zfs.stdout.on('data', function(chunk) {
     data = data + chunk.toString();
@@ -333,42 +339,46 @@ getRecursive = function(name, callback) {
      parseData();
   });
   
-}
+};
 
-getClones = function(name, callback) {
+var getClones = function(name, callback) {
   assert.ok(name);
   assert.ok(callback);
 
   list(null, function(err, datasets) {
-    if (err) return callback(err, null);
+    if (err) {
+      return callback(err, null);
+    }
     var clones = [];
     for (var i=0; i<datasets.length; i++) {
       // console.log(datasets[i].name);
-      if (datasets[i].origin == name) {
+      if (datasets[i].origin === name) {
         clones.push(datasets[i]);
       }
-    } 
+    }
    callback(err, clones);
-  });  
+  });
    
-}
+};
 
-getSnapshots = function(name, callback) {
+var getSnapshots = function(name, callback) {
   assert.ok(name);
   assert.ok(callback);
 
   getRecursive(name, function(err, datasets) {
-    if (err) return callback(err, null);
+    if (err) {
+      return callback(err, null);
+    }
     datasets.shift(); // first result is the actual dataset
 
     callback(null, datasets);
   });
-}
+};
 
 // returns a full list of all datasets
-list = function(options, callback) {
+var list = function(options, callback) {
   var _options = {
-    type: 'all' // valid are snapshot, vol, 
+    type: 'all' // valid are snapshot, vol,
   };
 
   var data = '';
@@ -376,12 +386,12 @@ list = function(options, callback) {
   var args = ['list', '-rpH', '-t', _options.type, '-o'];
   args.push(QUERY_PROPERTIES.join(','));
   
-  zfs = spawn(ZFS, args);
+  var zfs = spawn(ZFS, args);
   
-  parseData = function() {
+  var parseData = function() {
     var datasets = [];
     var lines = data.split(/\n/);
-    for (var i=0; i<lines.length; i++) { 
+    for (var i=0; i<lines.length; i++) {
       var line = lines[i].split(/\t/);
       var dataset = {};
       
@@ -406,7 +416,7 @@ list = function(options, callback) {
 
   zfs.stderr.on('data', function(chunk) {
     callback(newError(ERR_LIST, "error listing datasets"), null);
-  });  
+  });
   
   zfs.on('exit', function(code, signal) {
     parseData();
@@ -415,24 +425,26 @@ list = function(options, callback) {
 };
 
 
-snapshot = function(name, options, callback) {
+var snapshot = function(name, options, callback) {
   assert.ok(name);
   var _options = {
     recursive: false,  // bool
     property: null     // must be an array
-  } 
+  };
  
   var error = null;
   var args = ['snapshot'];
 
-  if (_options.recursive == true) args.push('-r');
+  if (_options.recursive === true) {
+    args.push('-r');
+  }
   if (_options.property) {
-    args.push(_options.property[0] + '=' + _options.property[1]); 
-  };
+    args.push(_options.property[0] + '=' + _options.property[1]);
+  }
 
   args.push(name);
 
-  zfs = spawn(ZFS, args);
+  var zfs = spawn(ZFS, args);
  
   zfs.stderr.on('data', function(chunk) {
     error = newError(ERR_SNAP, "error taking snapshot" + chunk);
@@ -441,20 +453,22 @@ snapshot = function(name, options, callback) {
   zfs.on('exit', function(code, signal) {
     callback(error);
   });
-}
+};
 
-destroy = function(name, options, callback) {
+var destroy = function(name, options, callback) {
   assert.ok(name);
   
-  var options = options || { recursive: false };
+  options = options || { recursive: false };
 
   var error = null;
   var args = ['destroy'];
 
-  if (options.recursive == true) args.push('-r');
+  if (options.recursive === true) {
+    args.push('-r');
+  }
   args.push(name);
 
-  zfs = spawn(ZFS, args);
+  var zfs = spawn(ZFS, args);
 
   zfs.stderr.on('data', function(chunk) {
     error = newError(ERR_DESTROY, "error destroying snapshot" + chunk);
@@ -464,23 +478,23 @@ destroy = function(name, options, callback) {
     callback(error);
   });
 
-}
+};
 
-setProp = function(name, property, value, callback) {
+var setProp = function(name, property, value, callback) {
   assert.ok(name);
   assert.ok(property);
   assert.ok(value);
-  assert.ok(callback); 
+  assert.ok(callback);
 
   var args = ['set'];
   args.push(property + '=' + value);
-  args.push(name);  
+  args.push(name);
 
-  var err
+  var err;
   var zfs = spawn(ZFS, args);
 
   zfs.on('exit', function(code, signal) {
-    callback(err);  
+    callback(err);
   });
 
   zfs.stderr.on('data', function(chunk) {
@@ -489,7 +503,7 @@ setProp = function(name, property, value, callback) {
 
 };
 
-rename = function(name, newname, callback) {
+var rename = function(name, newname, callback) {
   assert.ok(name);
   assert.ok(newname);
 
@@ -497,16 +511,20 @@ rename = function(name, newname, callback) {
   var zfs = spawn(ZFS, args);
 
   zfs.on('exit', function(code, signal) {
-    if (callback) callback(null);
+    if (callback) {
+      callback(null);
+    }
   });
 
   zfs.stderr.on('data', function(chunk) {
-    if (callback) callback(newError(ERR_RENAME, "error renaming dataset"));
+    if (callback) {
+      callback(newError(ERR_RENAME, "error renaming dataset"));
+    }
   });
  
 };
 
-receiveStream = function(name, readStream, callback) {
+var receiveStream = function(name, readStream, callback) {
   assert.ok(name);
   assert.ok(readStream);
   assert.ok(callback);
@@ -521,7 +539,7 @@ receiveStream = function(name, readStream, callback) {
 
   zfs.on('exit', function(code, signal) {
     return callback();
-  }); 
+  });
 
   zfs.stderr.on('data', function(chunk) {
     callback(newError(ERR_RECV, "error receiving dataset"));
@@ -529,7 +547,7 @@ receiveStream = function(name, readStream, callback) {
 
 };
 
-spawnReceiveStream = function(name) {
+var spawnReceiveStream = function(name) {
   assert.ok(name);
 
   var args = ['recv'];
@@ -542,12 +560,12 @@ spawnReceiveStream = function(name) {
   
 };
 
-sendStream = function(name, writeStream, callback) {
+var sendStream = function(name, writeStream, callback) {
   assert.ok(name);
   assert.ok(writeStream);
   assert.ok(callback);
 
-  var args = ['send']; 
+  var args = ['send'];
   args.push(name);
   
   var zfs = spawn(ZFS, args);
@@ -564,7 +582,7 @@ sendStream = function(name, writeStream, callback) {
 
 };
 
-getPool = function(name, callback) {
+var getPool = function(name, callback) {
   assert.ok(name);
   assert.ok(callback);
 
@@ -572,20 +590,21 @@ getPool = function(name, callback) {
  
   listPool(null, function(err, pools) {
     for (var i=0; i<pools.length; i++) {
-      if (pools[i].name === name) 
+      if (pools[i].name === name) {
         pool = pools[i];
+      }
     }
     callback(err, pool);
-  }); 
+  });
 };
 
-listPool = function(options, callback) {
+var listPool = function(options, callback) {
   assert.ok(callback);
      
   var args = ['list', '-pH', '-o'];
   args.push(ZPOOL_PROPERTIES.join(','));
   
-  var pools = []; 
+  var pools = [];
   var zpool = spawn(ZPOOL, args);
   
   zpool.stdout.on('data', function(chunk) {
@@ -594,19 +613,21 @@ listPool = function(options, callback) {
       var line = lines[i].split(/\t/);
       var pool = {};
       
-      if (line.length === 1) continue;
+      if (line.length === 1) {
+        continue;
+      }
       
       for (var p=0; p<ZPOOL_PROPERTIES.length; p++) {
         var val = line[p];
         var prop = ZPOOL_PROPERTIES[p];
       
-        val = _formatPoolProperty(prop, val)[1]; 
+        val = _formatPoolProperty(prop, val)[1];
       
         pool[prop] = val;
       }
       
       pools.push(pool);
-    } 
+    }
   });
 
   zpool.on('exit', function(code, signal) {
@@ -630,4 +651,4 @@ module.exports = {
   rename: rename,
   listPool: listPool,
   getPool: getPool
-}
+};


### PR DESCRIPTION
I have cleaned up the ZFS module used by `dsadm` since it basically looked like a mess :P
The only things JSHint complain about now, is that `'use strict';´ is missing, and that the variable`ERR_SEND` is used, but not defined anywhere - which seems like a mistake to me.
