### PR TITLE
Suggestion: Add Spice Remote display support

### DIFF
--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -278,6 +278,11 @@ exports.VGA_TYPES = [
     'xenfb'
 ];
 
+exports.SOUNDHW_TYPES = [
+    'pcspk',
+    'ac97'
+];
+
 exports.INFO_TYPES = [
     'all',
     'version',
@@ -287,6 +292,7 @@ exports.INFO_TYPES = [
     'cpus',
     'pci',
     'kvm',
+    'spice',
     'vnc'
 ];
 
@@ -326,8 +332,12 @@ var XML_PROPERTIES = {
         'transition': 'transition',
         'never-booted': 'never_booted',
         'vga': 'vga',
+        'soundhw': 'soundhw',
         'vnc-password': 'vnc_password',
         'vnc-port': 'vnc_port',
+        'spice-port': 'spice_port',
+        'spice-password': 'spice_password',
+        'spice-opts': 'spice_opts',
         'qemu-opts': 'qemu_opts',
         'qemu-extra-opts': 'qemu_extra_opts',
         'resolvers': 'resolvers',
@@ -388,6 +398,9 @@ var XML_PROPERTY_TRANSFORMS = {
     'alias': unbase64,
     'vnc_password': unbase64,
     'vnc_port': numberify,
+    'spice_password': unbase64,
+    'spice_port': numberify,
+    'spice_opts': unbase64,
     'qemu_opts': unbase64,
     'qemu_extra_opts': unbase64,
     'autoboot': fixBoolean,
@@ -2614,6 +2627,13 @@ function checkProperties(payload, vmobj, callback)
                 + '", supported types are: ' + VM.VGA_TYPES.join(',')));
             return;
         }
+        if (payload.hasOwnProperty('soundhw')
+            && VM.SOUNDHW_TYPES.indexOf(payload.soundhw) === -1) {
+
+            callback(new Error('Invalid SoundHW type: "' + payload.soundhw
+                + '", supported types are: ' + VM.SOUNDHW_TYPES.join(',')));
+            return;
+        }
 
         // Ensure password is not too long
         if (payload.hasOwnProperty('vnc_password')
@@ -3121,7 +3141,9 @@ function buildZonecfgUpdate(vmobj, payload)
         setAttr('boot', 'boot');
         setAttr('cpu-type', 'cpu_type');
         setAttr('vga', 'vga');
+        setAttr('soundhw', 'soundhw');
         setAttr('vnc-port', 'vnc_port');
+        setAttr('spice-port', 'spice_port');
 
         // we use base64 here for these next three options, since these can
         // contain characters zonecfg doesn't like.
@@ -3144,6 +3166,30 @@ function buildZonecfgUpdate(vmobj, payload)
 
             setAttr('vnc-password', 'vnc_password',
                 new Buffer(payload.vnc_password).toString('base64'));
+        }
+        if (payload.hasOwnProperty('spice_password')) {
+            if (payload.spice_password === ''
+                && (vmobj.hasOwnProperty('spice_password')
+                && vmobj.spice_password !== '')) {
+
+                VM.log('WARN', 'Warning: SPICE password was removed for VM '
+                    + vmobj.uuid + ' but VM needs to be restarted for change to'
+                    + 'take effect.');
+            }
+            if (payload.spice_password.length > 0
+                && !vmobj.hasOwnProperty('spice_password')) {
+
+                VM.log('WARN', 'Warning: SPICE password was added to VM '
+                    + vmobj.uuid + ' but VM needs to be restarted for change to'
+                    + 'take effect.');
+            }
+
+            setAttr('spice-password', 'spice_password',
+                new Buffer(payload.spice_password).toString('base64'));
+        }
+        if (payload.hasOwnProperty('spice_opts')) {
+            setAttr('spice-opts', 'spice_opts',
+                new Buffer(payload.spice_opts).toString('base64'));
         }
         if (payload.hasOwnProperty('qemu_opts')) {
             setAttr('qemu-opts', 'qemu_opts',
@@ -3712,6 +3758,9 @@ function startVM(vmobj, extra, callback)
     var script;
     var uuid = vmobj.uuid;
     var vnic_opts;
+    var spiceargs;
+    var new_qemu = false;
+    var qemu_exe;
 
     VM.log('DEBUG', 'startVM(' + uuid + ')');
 
@@ -3722,6 +3771,18 @@ function startVM(vmobj, extra, callback)
     }
 
     // XXX TODO: validate vmobj data is ok to start
+
+    // First we check for the new_qemu binary so we can adjust
+    // our arguments accordingly.
+    check_path = path.join(vmobj.zonepath, 'root', 
+                           '/smartdc2/bin/qemu-system-x86_64');
+    if (path.existsSync(check_path)) {
+        new_qemu = true;
+        qemu_exe = '/smartdc2/bin/qemu-system-x86_64'
+        cmdargs.push('-machine', 'pc,accel=kvm,kernel_irqchip=on');
+    } else {
+        qemu_exe = '/smartdc/bin/qemu-system-x86_64'
+    }
 
     cmdargs.push('-m', vmobj.ram);
     cmdargs.push('-name', vmobj.uuid);
@@ -3745,7 +3806,7 @@ function startVM(vmobj, extra, callback)
             }
             diskargs = 'file=' + disk.path + ',if=' + disk.model
                 + ',index=' + disk_idx + ',media=' + disk.media;
-            if (disk.boot) {
+            if (disk.boot && !new_qemu) {
                 diskargs = diskargs + ',boot=on';
             }
             cmdargs.push('-drive', diskargs);
@@ -3787,7 +3848,7 @@ function startVM(vmobj, extra, callback)
                 }
                 diskargs = 'file=' + disk.path + ',if=' + disk.model
                     + ',index=' + disk_idx + ',media=' + disk.media;
-                if (disk.boot) {
+                if (disk.boot && !new_qemu) {
                     diskargs = diskargs + ',boot=on';
                 }
                 cmdargs.push('-drive', diskargs);
@@ -3884,6 +3945,10 @@ function startVM(vmobj, extra, callback)
         cmdargs.push('-vga', 'cirrus');
     }
 
+    if (vmobj.hasOwnProperty('soundhw')) {
+        cmdargs.push('-soundhw', vmobj.soundhw);
+    }
+
     cmdargs.push('-chardev',
         'socket,id=qmp,path=/tmp/vm.qmp,server,nowait');
     cmdargs.push('-qmp', 'chardev:qmp');
@@ -3906,6 +3971,29 @@ function startVM(vmobj, extra, callback)
         } else {
             cmdargs.push('-vnc', 'unix:/tmp/vm.vnc');
         }
+        if (vmobj.hasOwnProperty('spice_port')
+                && vmobj.spice_port != -1) {
+
+                spiceargs='sock=/tmp/vm.spice'
+                if (vmobj.hasOwnProperty('spice_password')
+                    && vmobj.spice_password.length > 0) {
+               
+                    // Spice password is set via qmp, so we don't
+                    // need to do anything here
+                } else {
+                    spiceargs = spiceargs + ',disable-ticketing';
+                }
+                if (vmobj.hasOwnProperty('spice_opts')
+                    && vmobj.spice_opts.length > 0) {
+    
+                    spiceargs = spiceargs + ',' + vmobj.spice_opts;
+                }
+                cmdargs.push('-spice', spiceargs);
+                cmdargs.push('-device', 'virtio-serial-pci');
+                cmdargs.push('-device', 'virtserialport,chardev=spicechannel0,' +
+                                        'name=com.redhat.spice.0');
+                cmdargs.push('-chardev', 'spicevmc,id=spicechannel0,name=vdagent');
+        }
         cmdargs.push('-parallel', 'none');
         cmdargs.push('-usb');
         cmdargs.push('-usbdevice', 'tablet');
@@ -3922,12 +4010,13 @@ function startVM(vmobj, extra, callback)
     script = '#!/usr/bin/bash\n\n'
         + 'exec >/tmp/vm.startvm.log 2>&1\n\n'
         + 'set -o xtrace\n\n'
+        + (new_qemu ? 'export LD_LIBRARY_PATH=/lib/64:/usr/lib/64:/smartdc2/lib\n' : '')
         + 'if [[ -x /startvm.zone ]]; then\n'
         + '    exec /smartdc/bin/qemu-exec /startvm.zone "'
         + cmdargs.join('" "')
         + '" ' + qemu_opts + '\n'
         + 'else\n'
-        + '    exec /smartdc/bin/qemu-exec /smartdc/bin/qemu-system-x86_64 "'
+        + '    exec /smartdc/bin/qemu-exec ' + qemu_exe + ' "'
         + cmdargs.join('" "')
         + '" ' + qemu_opts + '\n'
         + 'fi\n\n'


### PR DESCRIPTION
Here's an initial suggestion for incorporating spice, happy to adjust as needed:

This adds support for Spice remote displays in a similar way to VNC displays.
Adds: "spice_port", "spice_password" and "spice_opts" options
Also adds: "soundhw" to enable sound
Also adds: "spice" as an info target
If spice_port is set (and > 0) then it will be the remote display and VNC will not be used.
This also includes fixes to the net.server code to allow socket closure to do the right thing (as far as I can see!!)

Also, this detects the presence of the newer qemu binary (as per mailing list) and adjust the arguments accordingly.

It would be tidier to do this as a set of "remote display" options, including one to decide if it's spice or vnc, however that wouldn't be backwards compatible so I just added spice as a separate set of options.

Regards,

Lee.
