### PR TITLE
Output of the sysinfo command gets corrupted with more than one zpool

### DIFF
--- a/src/sysinfo
+++ b/src/sysinfo
@@ -233,7 +233,9 @@ function get_zpool_profile()
 function get_zpool()
 {
 	if [[ $(zpool list) != "no pools available" ]]; then
-		Zpool=$(zpool list -H | awk '{print $1}');
+		# Zpool=$(zpool list -H | awk '{print $1}');
+		# only use the system zpool; the 'zpool list' variant fails with more than one zpool available
+		Zpool=$(svcprop -p "config/zpool" svc:/system/smartdc/init);
 
 	        local used=$(zfs get -Hp -o value used ${Zpool})
 	        local available=$(zfs get -Hp -o value available ${Zpool})


### PR DESCRIPTION
If the system uses more than one zpool `sysinfo -u` fails with a syntax error:

```
[root@1c-6f-65-cf-04-88 ~]# sysinfo -u
/usr/bin/sysinfo: line 240: 3651178756166
13245571584 + 751210956730
301729881600 : syntax error in expression (error token is "13245571584 + 751210956730
301729881600 ")
```

this gets `sysinfo` output corrupted and `vmadmd` fails to start:

```
+ /usr/bin/ctrun -l child -o noorphan /usr/vm/sbin/vmadmd
[ Apr 12 04:29:42 Method "start" exited with status 0. ]

node.js:201
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
SyntaxError: Unexpected token ,
    at Object.parse (native)
    at /usr/vm/sbin/vmadmd:60:24
    at ChildProcess.exithandler (child_process.js:280:7)
    at ChildProcess.emit (events.js:70:17)
    at maybeExit (child_process.js:360:16)
    at Socket.<anonymous> (child_process.js:465:7)
    at Socket.emit (events.js:67:17)
    at Array.1 (net.js:320:10)
    at EventEmitter._tickCallback (node.js:192:40)
```

I changed the `get_zpool` function to just use the configured system zpool.

Because of the property "Zpool" where only one pool is list iterating over all available zpools and adding used and available space for each would not be correct i guess.

Or is there a better alternative? :)
