### PR TITLE
`gmake world` fails while executing tools/build_illumos

### DIFF
--- a/configure
+++ b/configure
@@ -103,6 +103,9 @@ if [ ! -f "/opt/SUNWspro/prod/bin/cc" ]; then
     (cd /opt/ \
       && curl -k "${SUNW_SPRO12_URL}" \
       | ${ROOTCMD} gtar -jxf -)
+    if [ ! -d "/opt/SUNWspro/sunstudio12.1" ]; then
+      ln -s . /opt/SUNWspro/sunstudio12.1
+    fi
   else
     echo "FATAL: unable to download sunstudio12, no URL is set.  Please set SUNW_SPRO12_URL in configure.*"
     exit 1


### PR DESCRIPTION
The build_illumos step tries to use /opt/SUNWspro/sunstudio12.1/bin/lint which is not available by default.

Creating a symlink fixes the build.

```
ln -s . /opt/SUNWspro/sunstudio12.1
```

This symlink should probably be added to https://download.joyent.com/pub/build/SunStudio.tar.bz2
