### PR TITLE
`sysinfo -u` fails updating the cache file if more than one zpool is available

### DIFF
--- a/src/sysinfo
+++ b/src/sysinfo
@@ -233,7 +233,7 @@ function get_zpool_profile()
 function get_zpool()
 {
 	if [[ $(zpool list) != "no pools available" ]]; then
-		Zpool=$(zpool list -H | awk '{print $1}');
+		Zpool=$(svcprop -p "config/zpool" svc:/system/smartdc/init);
 
 	        local used=$(zfs get -Hp -o value used ${Zpool})
 	        local available=$(zfs get -Hp -o value available ${Zpool})


### PR DESCRIPTION
```
[root@1c-6f-65-cf-04-88 ~]# sysinfo -u
/usr/bin/sysinfo: line 240: 3651178756166
13245571584 + 751210956730
301729881600 : syntax error in expression (error token is "13245571584 + 751210956730
301729881600 ")
```

with the corrupt cache file vmadmd fails to start and the system is not usable.

I changed the get_zpool() to only include the system pool.
