### PR TITLE
'make clean' fails if Node.js hasn't been built

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -101,6 +101,8 @@ vm/tests.tar.gz:
 
 clean:
 	@rm -f $(TARGETS) $(SMARTDC_TARGETS)
-	(cd node-kstat && $(NODE_WAF) clean)
-	(cd node-expat && $(NODE_WAF) clean)
-	(cd node-syslog && $(NODE_WAF) clean)
+	if test -f $(NODE_WAF); then \
+		(cd node-kstat && $(NODE_WAF) clean); \
+		(cd node-expat && $(NODE_WAF) clean); \
+		(cd node-syslog && $(NODE_WAF) clean); \
+	fi


### PR DESCRIPTION
In case you experience an issue somewhere in the build process and want to start over with a 'make clean', it will fail right from the get go if you don't have Node.js built because `node-waf` is missing from the proto area.
I have added a simple check to make sure `node-waf` exists before trying to call it, which will make 'make clean' complete if that's not the case.
