### PR TITLE
fixed a problem with DSadm and multople sources.

### DIFF
--- a/src/ds/node_modules/dsadm.js
+++ b/src/ds/node_modules/dsadm.js
@@ -262,8 +262,16 @@ var cacheUpdate = function (callback) {
 
     var source = sources[i];
     var options = url.parse(sources[i]);
-
-    (function(options,source) { //we have to hack aground silly scoping
+    /*The extra lambda around the funcion call of dns.resolve4
+      Is rather ugly but it is required to solve a scoping problem.
+      Without it options and source will 'run away' through the 
+      for loop and all callbacks end up with the same options and
+      sourece (the laste one). This problem is not visible with one
+      entry only but gets triggered if there are two or more.
+      A simplyfied version of this problem can be seen here:
+      https://gist.github.com/2595753
+     */
+    (function(options,source) {
       // SmartOS DNS is disabled by default
       dns.resolve4(options.hostname, function(err, addresses) {
         var body = "";


### PR DESCRIPTION
The variable scope caused dsadm to not use a fresh body string when fetching sources from multiple servers - the second server would still see the body from the first, causing malformed JSON. Moving the variable body in a more inner scope fixed that.
Also when multiple hosts where provided the decoded path got mixed up with not matching IP's/hostnames.
