### PR TITLE
adds "allow_ip_conflict" boolean option to nics

### DIFF
--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -243,6 +243,7 @@ var UPDATABLE_NIC_PROPS = [
     'netmask',
     'dhcp_server',
     'allow_dhcp_spoofing',
+    'allow_ip_conflict',
     'allow_ip_spoofing',
     'allow_mac_spoofing',
     'allow_restricted_traffic',
@@ -389,6 +390,7 @@ var XML_PROPERTIES = {
         'global-nic': 'nic_tag',
         'dhcp_server': 'dhcp_server',
         'allow_dhcp_spoofing': 'allow_dhcp_spoofing',
+        'allow_ip_conflict': 'allow_ip_conflict',
         'allow_ip_spoofing': 'allow_ip_spoofing',
         'allow_mac_spoofing': 'allow_mac_spoofing',
         'allow_restricted_traffic': 'allow_restricted_traffic',
@@ -441,6 +443,7 @@ var XML_PROPERTY_TRANSFORMS = {
     'nics': {
         'dhcp_server': fixBoolean,
         'allow_dhcp_spoofing': fixBoolean,
+        'allow_ip_conflict': fixBoolean,
         'allow_ip_spoofing': fixBoolean,
         'allow_mac_spoofing': fixBoolean,
         'allow_restricted_traffic': fixBoolean,
@@ -621,6 +624,7 @@ var joyent_allowed = {
     'max_swap': ['create', 'receive', 'update'],
     'nics': ['create', 'receive'],
     'nics.*.allow_dhcp_spoofing': ['add', 'update'],
+    'nics.*.allow_ip_conflict': ['add', 'update'],
     'nics.*.allow_ip_spoofing': ['add', 'update'],
     'nics.*.allow_mac_spoofing': ['add', 'update'],
     'nics.*.allow_restricted_traffic': ['add', 'update'],
@@ -767,6 +771,7 @@ var BRAND_OPTIONS = {
             'max_swap': ['create', 'receive', 'update'],
             'nics': ['create', 'receive'],
             'nics.*.allow_dhcp_spoofing': ['add', 'update'],
+            'nics.*.allow_ip_conflict': ['add', 'update'],
             'nics.*.allow_ip_spoofing': ['add', 'update'],
             'nics.*.allow_mac_spoofing': ['add', 'update'],
             'nics.*.allow_restricted_traffic': ['add', 'update'],
@@ -3812,7 +3817,8 @@ function checkPayloadProperties(payload, vmobj, callback)
                         }
                     }
 
-                    if (n.hasOwnProperty('ip') && n.ip != 'dhcp') {
+                    if (!(n.hasOwnProperty('allow_ip_conflict') && n.allow_ip_conflict)
+                        && n.hasOwnProperty('ip') && n.ip != 'dhcp') {
                         if (ips.indexOf(n.ip) !== -1
                             || current_ips.indexOf(n.ip) !== -1) {
 
@@ -4180,8 +4186,8 @@ function buildNicZonecfg(vmobj, payload)
     // properties that don't require any validation - add them if they're
     // present:
     var nicProperties = ['ip', 'netmask', 'model', 'dhcp_server',
-        'allow_dhcp_spoofing', 'blocked_outgoing_ports', 'allow_ip_spoofing',
-        'allow_mac_spoofing', 'allow_restricted_traffic',
+        'allow_dhcp_spoofing', 'blocked_outgoing_ports', 'allow_ip_conflict', 
+        'allow_ip_spoofing', 'allow_mac_spoofing', 'allow_restricted_traffic',
         'allow_unfiltered_promisc'];
 
     for (nic in add) {


### PR DESCRIPTION
This option allows two nics on different zones to have the same ip address.
This is useful if you have zones on different etherstubs or any other creative use case.
