### PR TITLE
vmadm lookup does not work for some quick_lookup fields

### DIFF
--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -2190,6 +2190,7 @@ exports.lookup = function (search, options, callback) {
             var full_results = [];
             var match;
             var regex;
+            var source;
             var target;
             var u;
             var z;
@@ -2203,14 +2204,18 @@ exports.lookup = function (search, options, callback) {
                 match = true;
                 for (key in search) {
                     regex = false;
+                    // force field type to string so that earlier
+                    // transformed number fields get back their match method
+                    // and the strict not-equal operator will work on number lookups
+                    source = "" + z[key];
                     target = search[key];
                     if (target[0] === '~') {
                         target = new RegExp(target.substr(1), 'i');
                         regex = true;
                     }
-                    if (regex && !z[key].match(target)) {
+                    if (regex && !source.match(target)) {
                         match = false;
-                    } else if (!regex && (z[key] !== search[key])) {
+                    } else if (!regex && (source !== search[key])) {
                         match = false;
                     }
                 }


### PR DESCRIPTION
After applied transformations not all attributes of the zone payload are strings anymore.

If the attribute is no string the .match method for RegEx searches is not available and a strict match against a string in the search object always fails.

To reproduce this behavior just try to match a zoneid field:
`vmadm lookup zoneid=1` or `vmadm lookup zoneid=~1`

The RegEx match will return a TypeError:

```
/usr/vm/node_modules/VM.js:2211
                    if (regex && !z[key].match(target)) {
                                         ^
TypeError: Object 1 has no method 'match'
    at exports.lookup (/usr/vm/node_modules/VM.js:2211:42)
    at /usr/vm/node_modules/VM.js:1701:9
    at _asyncMap (/usr/node/0.8/node_modules/async.js:166:13)
    at async.forEachSeries.iterate (/usr/node/0.8/node_modules/async.js:129:25)
    at _asyncMap (/usr/node/0.8/node_modules/async.js:163:17)
    at async.series.results (/usr/node/0.8/node_modules/async.js:461:34)
    at /usr/vm/node_modules/VM.js:1696:17
    at async.forEachSeries.iterate (/usr/node/0.8/node_modules/async.js:129:25)
    at /usr/vm/node_modules/VM.js:1693:21
    at async.forEachSeries.iterate (/usr/node/0.8/node_modules/async.js:121:13)
```

My patch simply forces the quick_lookup fields back to a string before matching.
Properties that are not part of the quick_lookup list seem to match fine.
