### PR TITLE
imgadm show does not work with manually installed images

### DIFF
--- a/src/img/node_modules/imgadm.js
+++ b/src/img/node_modules/imgadm.js
@@ -354,6 +354,7 @@ var cacheUpdate = function (callback) {
 var show = function (uuid, callback) {
     var cache = loadCache(DB_CACHE);
     var i;
+    var manifest;
     var result = null;
 
     if (!cache) {
@@ -371,7 +372,13 @@ var show = function (uuid, callback) {
     if (result) {
         callback(null, result);
     } else {
-        callback('not found', null);
+        // check for manually installed image
+        manifest = '/var/db/imgadm/' + uuid + '.json';
+        if (fs.existsSync(manifest)) {
+            callback(null, JSON.parse(fs.readFileSync(manifest)));
+        } else {
+            callback('not found', null);
+        }
     }
 };
 


### PR DESCRIPTION
`imgadm show` is just checking the cache available from the repository server. If you try to get info on an image installed via `imgadm install` it just exists with

```
Error: not found
```

This patch searches for already installed images if the uuid is not in the cache.
