### PR TITLE
imgadm-repair destroys the imgadm database

### DIFF
--- a/src/img/sbin/imgadm-repair
+++ b/src/img/sbin/imgadm-repair
@@ -51,7 +51,7 @@ for i in ${zvols[@]} ; do
     echo "Checking for manifest with UUID: $i"
     manifest=$(imgadm show $i)
 
-    if [[ -n $manifest ]] ; then
+    if [[ "$?" == "0" && -n $manifest ]] ; then
         echo "$i - manifest was found. Copying to $DBDIR"
         echo "${manifest}" > $DBDIR/$i.json
         urn=$(cat $DBDIR/$i.json | json urn)

--- a/src/img/sbin/imgadm-repair
+++ b/src/img/sbin/imgadm-repair
@@ -48,13 +48,13 @@ zvols=$(zfs list -pH -o name -t snapshot \
 for i in ${zvols[@]} ; do
     unset manifest
     unset urn
-    echo 'Checking for manifest with UUID: $i'
-    manifest=$(imgadm get $i)
+    echo "Checking for manifest with UUID: $i"
+    manifest=$(imgadm show $i)
 
     if [[ -n $manifest ]] ; then
-        echo '$i - manifest was found. Copying to $DBDIR'
-        echo '${manifest}' > $DBDIR/$i.json
+        echo "$i - manifest was found. Copying to $DBDIR"
+        echo "${manifest}" > $DBDIR/$i.json
         urn=$(cat $DBDIR/$i.json | json urn)
-        echo '$i - urn: $urn'
+        echo "$i - urn: $urn"
     fi
 done


### PR DESCRIPTION
the variables in single-quotes don't get replaced so imgadm-repair writes `${manifest}` into all json files which breaks everything else that should work with the file.

imgadm-repair tried to update locally imported manifest which are not found in the cache file - that would save an empty manifest file.

this pull request fixes #129