### PR TITLE
Handle deleting VM:s with snapshots

### DIFF
--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -6035,7 +6035,8 @@ exports.create = function (payload, callback)
 // delete a zvol
 function deleteVolume(volume, callback)
 {
-    var args = ['destroy', '-F', volume.zfs_filesystem];
+    // use recursive delete to handle possible snapshots on volume
+    var args = ['destroy', '-rF', volume.zfs_filesystem];
 
     if (volume.missing) {
         // this volume doesn't actually exist, so skip trying to delete.


### PR DESCRIPTION
This prevents "vmadm delete" from failing on VM:s that have snapshots
and makes the behavior consistent with that of deleting SmartMachines.

(fixes #113)
