### PR TITLE
imgadm should send Host header in HTTP requests

### DIFF
--- a/src/img/node_modules/imgadm.js
+++ b/src/img/node_modules/imgadm.js
@@ -661,7 +661,7 @@ var importRemote = function (uuid, callback) {
                     }
 
                     args.push('--header');
-                    args.push('"Host: ' + options.hostname + '"');
+                    args.push('Host: ' + options.hostname);
 
                     options.host = addresses[0];
                     delete (options.hostname); // XXX


### PR DESCRIPTION
This request adds the "Host" header to the HTTP requests for the manifest list and the image files.

This is needed to serve manifests and files for imgadm using a named host configuration -- that is, one in which several sites co-exist on a single IP and the server decides which you wanted based entirely on the Host header you send.
