### PR TITLE
make imgadm to use http(s)_proxy environment variables

### DIFF
--- a/src/img/node_modules/imgadm.js
+++ b/src/img/node_modules/imgadm.js
@@ -58,8 +58,6 @@ var common = require('./common');
 var db = require('./db');
 var dns = require('dns');
 var fs = require('fs');
-var http = require('http');
-var https = require('https');
 var log = common.log;
 var path = require('path');
 var spawn = require('child_process').spawn;
@@ -141,65 +139,6 @@ var imageExists = function (uuid, callback) {
             callback(true);
         }
     });
-};
-
-var httpOptions = function (manifestId, callback) {
-    var auth;
-    var opts;
-    var s;
-
-    if (!manifestId) {
-        opts = url.parse(IMGAPI_URL);
-    } else if (_isUrl(manifestId)) {
-        opts = url.parse(manifestId);
-    } else if (_isUuid(manifestId)) {
-        opts = url.parse(IMGAPI_URL + manifestId);
-    } else {
-        throw new Error('options requires a URL or UUID');
-    }
-
-    opts.headers = {
-        'accept': 'application/json'
-    };
-
-    // nodev4 fixup (url and http client reqs dont match)
-    if (opts.pathname) {
-        opts.path = opts.pathname;
-        opts.pathname = undefined;
-    }
-    if (opts.auth) {
-        s = opts.host.split(/@/);
-        opts.host = s[s.length-1];
-        auth = 'Basic ' + new Buffer(opts.auth).toString('base64');
-        opts.headers['Authorization'] = auth;
-    }
-
-    // SmartOS DNS is disabled by default. We rely on node to
-    // resolve the host for us.
-    dns.resolve4(opts.hostname, function (err, addresses) {
-        if (err) {
-            throw new Error('could not resolve host: ' + opts.hostname);
-        }
-        // pick one at random?
-        opts.host = addresses[0];
-        callback(opts);
-    });
-};
-
-var httpClient = function (options) {
-    var client;
-
-    switch (options.protocol) {
-        case 'https:':
-            client = https;
-            break;
-        case 'http:':
-            client = http;
-            break;
-        default:
-            throw new Error('Unsupported protocol: ' + options.protocol);
-    }
-    return client;
 };
 
 // Todo just replace this with Array.filter and create

--- a/src/img/node_modules/imgadm.js
+++ b/src/img/node_modules/imgadm.js
@@ -314,7 +314,8 @@ var cacheUpdate = function (callback) {
 
         // SmartOS DNS is disabled by default
         dns.resolve4(options.hostname, function (err, addresses) {
-            var client;
+            var args = ['--insecure'];
+            var curl;
             var body = '';
 
             if (err) {
@@ -322,33 +323,30 @@ var cacheUpdate = function (callback) {
                 return;
             }
 
-            options.headers = {
-                'host': options.hostname
-            };
+            console.log('Get %s...', source);
+
+            args.push('--header');
+            args.push('Host: ' + options.hostname);
 
             options.host = addresses[0];
             delete (options.hostname); // XXX
+            args.push(_curlHost(options));
 
-            client = httpClient(options);
+            curl = spawn(CURL, args);
 
-            console.log('Get %s...', source);
+            curl.stdout.on('data', function (chunk) {
+                body += chunk.toString();
+            });
 
-            client.get(options, function (res) {
+            curl.stdout.on('end', function () {
+                var imgdb = JSON.parse(body);
+                for (var d = 0; d < imgdb.length; d++) {
+                    // set url property so relpaths work later
+                    imgdb[d]['_url'] = source;
+                    cache.push(imgdb[d]);
+                }
 
-                res.on('data', function (chunk) {
-                    body += chunk.toString();
-                });
-
-                res.on('end', function () {
-                    var imgdb = JSON.parse(body);
-                    for (var d = 0; d < imgdb.length; d++) {
-                        // set url property so relpaths work later
-                        imgdb[d]['_url'] = source;
-                        cache.push(imgdb[d]);
-                    }
-
-                    next();
-                });
+                next();
             });
         });
     });


### PR DESCRIPTION
This request changes imgadm to use curl for downloading manifests from dataset servers.

Curl respects http(s)_proxy environment variables during download so imgadm can also be used in behind proxies.

This fixes issue #120