### PR TITLE
'zfs list' output requires larger buffer size

### DIFF
--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -3278,7 +3278,7 @@ function zfs(args, callback)
     var cmd = '/usr/sbin/zfs';
 
     VM.log.debug(cmd + ' ' + args.join(' '));
-    execFile(cmd, args, function (error, stdout, stderr) {
+    execFile(cmd, args, {maxBuffer: 10 * 1024 * 1024}, function (error, stdout, stderr) {
         if (error) {
             callback(error, {'stdout': stdout, 'stderr': stderr});
         } else {


### PR DESCRIPTION
When running on a system with a certain amount of snapshots, the output
of 'zfs list' as run by loadDatasetInfo() becomes larger than the
default execFile() buffer size of 200 KB. This results in the output
being cut off somewhere mid stream and data silently missing in the
result.

This sets the buffer size to 10 MB, which is just yet another magic
constant that might be "large enough" or not. Perhaps some calculation
could be made based on expected number of zones, datasets, snapshots,
line length, etc...
