### PR TITLE
List snapshots separately from volumes+filesystems

### DIFF
--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -1584,7 +1584,7 @@ function setQuota(dataset, quota, callback)
  */
 function loadDatasetInfo(m, callback)
 {
-    var args;
+    var volfsargs, snapargs;
 
     volfsargs = ['list', '-H', '-p', '-t', 'volume,filesystem', '-o',
         'name,quota,volsize,mountpoint,type,compression,recsize,'


### PR DESCRIPTION
Listing snapshots with full properties takes a significant amount of
time, increasing the time for a 'vmadm list' from less than a second to
almost a minute on some systems. Since we're really only interested in
the snapshot names, issue a separate 'zfs list' for just that and merge
the data afterwards.

You might hate declaring a named function in the middle/end of another function. I did it that way to minimize the amount of changes and make the diff easier to review. If you want this refactored differently I'd be happy to do so.

The patched VM.js Works For Me(tm), but I'm not entirely sure where the snapshot data is used. I'm currently building and installing a system to run the test suite on, if that fails I'll retract the pull request or fix it.
