### PR TITLE
joyent/smartos-live#118 adding some services to joyent-minimal (not enabled or imported by default)

### DIFF
--- a/overlay/generic/usr/lib/brand/joyent-minimal/manifests
+++ b/overlay/generic/usr/lib/brand/joyent-minimal/manifests
@@ -125,3 +125,8 @@ system/early-manifest-import.xml	disabled
 system/manifest-import.xml	disabled
 system/mdata.xml	enabled
 system/cron.xml			disabled	noimport	
+network/forwarding.xml		disabled	noimport
+network/ipfilter.xml		disabled	noimport
+network/routing/legacy-routing.xml	disabled	noimport
+network/routing/ripng.xml	disabled	noimport
+network/routing/route.xml	disabled	noimport


### PR DESCRIPTION
This is a short term solution for a specific use-case.
A long-term solution for all use-cases is for joyent-minimal
to have everything in the "noimport" state by default
and explicitly enabling services currently imported and enabled.
