### PR TITLE
netmask mistakingly required for non-admin network dhcp

### DIFF
--- a/overlay/generic/lib/svc/method/net-physical
+++ b/overlay/generic/lib/svc/method/net-physical
@@ -116,7 +116,7 @@ function vnic_up
     typeset vlan_opt=
     typeset mac_addr_opt=
 
-    if [[ -z ${link} ]] || [[ -z ${iface} ]] || [[ -z ${ip} ]] || [[ -z ${netmask} ]]; then
+    if [[ -z ${link} ]] || [[ -z ${iface} ]] || [[ -z ${ip} ]] || ([[ ${ip} != "dhcp" ]] && [[ -z ${netmask} ]]); then
         echo "WARNING: not bringing up nic (insufficient configuration): $details"
         return
     fi


### PR DESCRIPTION
This should fix issue #218 where a vnic could not be brought up in dhcp mode,
unless a netmask was specified.
