### PR TITLE
fixed separateCommas() on empty string

### DIFF
--- a/src/vm/node_modules/utils.js
+++ b/src/vm/node_modules/utils.js
@@ -244,6 +244,10 @@ function rtrim(str, chars)
 
 function separateCommas(str)
 {
+    if (str.length === 0) {
+        return [];
+    }
+
     return str.split(',');
 }
 


### PR DESCRIPTION
Running String.split() on empty string produces an array with one -- empty string -- element (`[ "" ]`). This leads to the following problem:

Setting the `nics.*.allowed_ips` to empty array with `vmadm update` will successfully set the zone property to empty string, but the output of `vmadm get` is not reusable and for example a consecutive `vmadm send/receive` will fail with _invalid allowed_ips_.
