### PR TITLE
vmadm usage is missing uuid parameter for reprovision

### DIFF
--- a/src/vm/sbin/vmadm.js
+++ b/src/vm/sbin/vmadm.js
@@ -149,7 +149,7 @@ function usage(message, code)
     out('lookup [-j|-1] [-o field,...] [field=value ...]');
     out('reboot <uuid> [-F]');
     out('receive [-f <filename>]');
-    out('reprovision [-f <filename>]');
+    out('reprovision <uuid> [-f <filename>]');
     out('rollback-snapshot <uuid> <snapname>');
     out('send <uuid> [target]');
     out('start <uuid> [option=value ...]');


### PR DESCRIPTION
I know <code>vmadm reprovision</code> is currently undocumented.
But as far as I understand the code it always need the uuid parameter.

This change just fixes the vmadm usage output.