### PR TITLE
build: git --depth=1 sample.configure.smartos

### DIFF
--- a/sample.configure.smartos
+++ b/sample.configure.smartos
@@ -1,12 +1,12 @@
 mkdir -p projects/local
 (cd projects/local && [[ -d kvm ]] \
-    || git clone git://github.com/joyent/illumos-kvm kvm)
+    || git clone --depth=1 git://github.com/joyent/illumos-kvm kvm)
 (cd projects/local && [[ -d kvm-cmd ]] \
-    || git clone git://github.com/joyent/illumos-kvm-cmd kvm-cmd)
+    || git clone --depth=1 git://github.com/joyent/illumos-kvm-cmd kvm-cmd)
 (cd projects/local && [[ -d mdata-client ]] \
-    || git clone git://github.com/joyent/mdata-client mdata-client)
+    || git clone --depth=1 git://github.com/joyent/mdata-client mdata-client)
 (cd overlay && [[ -d smartos ]] \
-    || git clone git://github.com/joyent/smartos-overlay smartos)
+    || git clone --depth=1 git://github.com/joyent/smartos-overlay smartos)
 
 PUBLISHER="joyent"
 RELEASE_VER="smartos_20120112"
@@ -14,7 +14,7 @@ SUNW_SPRO12_URL="https://download.joyent.com/pub/build/SunStudio.tar.bz2"
 GCC44_URL="https://download.joyent.com/pub/build/gcc-4.tar.bz2"
 ON_CLOSED_BINS_URL="http://dlc.sun.com/osol/on/downloads/20100817/on-closed-bins.i386.tar.bz2"
 ON_CLOSED_BINS_ND_URL="http://dlc.sun.com/osol/on/downloads/20100817/on-closed-bins-nd.i386.tar.bz2"
-GET_ILLUMOS="(git clone git://github.com/joyent/illumos-joyent illumos)"
-GET_ILLUMOS_EXTRA="git clone git://github.com/joyent/illumos-extra illumos-extra"
+GET_ILLUMOS="(git clone --depth=1 git://github.com/joyent/illumos-joyent illumos)"
+GET_ILLUMOS_EXTRA="git clone --depth=1 git://github.com/joyent/illumos-extra illumos-extra"
 ILLUMOS_ADJUNCT_TARBALL_URL="https://download.joyent.com/pub/build/adjuncts/"
 OVERLAYS="smartos generic"


### PR DESCRIPTION
just added --depth=1 to every git clone in sample.configure.smartos

I just don't think there is any reason to clone full repository when we need just last snapshot.