### PR TITLE
make joyent-minimal brand more flexible

### DIFF
--- a/overlay/generic/lib/svc/method/svc-zones
+++ b/overlay/generic/lib/svc/method/svc-zones
@@ -137,6 +137,8 @@ setup_manifests()
 	do
 		brand=`basename $i`
 		[[ ! -f /usr/lib/brand/$brand/manifests ]] && continue
+		# joyent-minimal uses /zones/manifests/joyent too
+		[[ "$brand" == "joyent-minimal" ]] && continue
 		cp_brand_manifests $brand
 	done
 }

--- a/overlay/generic/usr/lib/brand/README.smf
+++ b/overlay/generic/usr/lib/brand/README.smf
@@ -34,20 +34,15 @@ does not apply to the KVM brand or the traditional ipkg and S10 branded zones.
 Each brand has a file called `manifests`. This file lists the set of manifests
 that the brand cares about being available to the zone. It is formatted as:
 
-<manifest_name> <enabled | disabled> [noimport]
+<manifest_name> <enabled | disabled>
 
 Examples are:
 
 network/smb/client.xml		disabled
 network/ssh.xml			enabled
-system/cron.xml			disabled	noimport
 
 The use of enabled or disabled determines the default disposition of the service
 when it is imported.
-
-The use of `noimport` is optional and has specific meaning for the
-joyent-minimal brand only at this time. Not specifying anything there is the
-equivalent of saying that this manifest should always be imported.
 
 This list is used in various places throughout the rest of the system for
 determining what shows up in the SMF repositories by default and what shows up
@@ -92,11 +87,11 @@ installed at zone creation time and replaces any existing repository.
 
 This seed repository is generated using the `svc.configd-native` and
 `svccfg-native` binaries. Every manifest listed in the brand's manifests file is
-included unless it has the `noimport` option specified. If that is the case, it
-will not be imported into the SMF repository by default, but will still be
+included.
+
+Manifests available to the `joyent` brand not imported into the database are
 available for manual import in /lib/svc/manifest. With the minimal brand, only
-the bare minimum number of manifests should be imported else that such a zone
-might want should be marked `noimport`.
+the bare minimum number of manifests should be imported.
 
 #
 # Using non-imported manifests

--- a/overlay/generic/usr/lib/brand/joyent-minimal/manifests
+++ b/overlay/generic/usr/lib/brand/joyent-minimal/manifests
@@ -5,7 +5,7 @@
 # should be listed here.
 #
 # The format of the file is:
-#	manifest_name enable/disable [noimport]
+#	manifest_name enable/disable
 # The manifest_name is found relative to /lib/svc/manifest on the system.
 # The second field is used to indicate if the svc should be enabled or
 # disabled by default within zones, independently of its current status in
@@ -78,6 +78,7 @@
 # system/boot-archive-update.xml
 # system/boot-archive.xml
 # system/boot-config.xml
+# system/cron.xml
 # system/fmd.xml
 # system/sac.xml
 #
@@ -124,4 +125,3 @@ milestone/name-services.xml	enabled
 system/early-manifest-import.xml	disabled
 system/manifest-import.xml	disabled
 system/mdata.xml	enabled
-system/cron.xml			disabled	noimport	

--- a/overlay/generic/usr/lib/brand/joyent-minimal/platform.xml
+++ b/overlay/generic/usr/lib/brand/joyent-minimal/platform.xml
@@ -37,7 +37,7 @@
 
 	<global_mount special="/lib" directory="/lib"
 	    opt="ro,nodevices" type="lofs" />
-	<global_mount special="%P/manifests/joyent-minimal" directory="/lib/svc/manifest"
+	<global_mount special="%P/manifests/joyent" directory="/lib/svc/manifest"
 	    opt="ro,nodevices" type="lofs" />
 	<global_mount special="%R/site" directory="/lib/svc/manifest/site"
 	    opt="nodevices" type="lofs" />

--- a/tools/build_seeds
+++ b/tools/build_seeds
@@ -89,10 +89,9 @@ function build_database
 	rm -f $SVCCFG_REPOSITORY
 
 	[[ -f $input ]] || fail "can't read manifest input file: $input"
-	while read service enabled import; do
+	while read service enabled; do
 		[[ -z "$service" ]] && continue
 		[[ "$service" =~ ^\# ]] && continue
-		[[ "$import" == "noimport" ]] && continue
 		import_manifest $service $enabled
 		
 		echo $service $enabled


### PR DESCRIPTION
fixes joyent/smartos-live#118

joyent-minimal and joyent brands now share the
/zones/manifests/joyent lofs mount

This is safe because the minimal brand overwrites the SMF repository of
whatever image is being used with its own minimal seed repository which
disables early-manifest-import and manifest-import

This change allows a joyent-minimal zone to import any other service
available to the joyent brand without maintaining a complicated brand
manifests file