### PR TITLE
OS-1293 mail warning: [ID 702911 mail.alert] unable to qualify my own domain name (headnode) -- using short name

### DIFF
--- a/overlay/generic/lib/svc/method/identity-node
+++ b/overlay/generic/lib/svc/method/identity-node
@@ -168,13 +168,13 @@ if [[ -z ${ipaddr} ]]; then
     ipaddr=$(set | grep "^SYSINFO_Network_Interface_.*_IPv4_Address" | head -n1 | cut -d'=' -f2)
 fi
 if [[ -n ${ipaddr} ]]; then
-    fullname=${hostname}
+    fullname=""
 
     if [ -n "$CONFIG_dns_domain" ]; then
-        fullname="${hostname}.${CONFIG_dns_domain}"
+        fullname=" ${hostname}.${CONFIG_dns_domain}"
     fi
 
-    printf "${ipaddr}\t${fullname}\n" >> /etc/hosts
+    printf "${ipaddr}\t${hostname}${fullname}\n" >> /etc/hosts
 fi
 
 # Reset the library path now that we are past the critical stage


### PR DESCRIPTION
Ported from sdc-platform, dropped use of e-mail address per IRC conversation with @rgulewich.

Diff from generic overlay to sdc-version at the time was:
```diff
--- overlay/generic/lib/svc/method/identity-node	2014-12-25 20:46:29.693126478 +0000
+++ overlay/sdc/lib/svc/method/identity-node	2014-12-25 17:54:04.783472448 +0000
@@ -32,6 +32,9 @@
 . /lib/svc/share/smf_include.sh
 . /lib/svc/share/net_include.sh

+. /lib/sdc/config.sh
+load_sdc_config
+
 set -o xtrace

 # Make sure that the libraries essential to this stage of booting can be found.
@@ -141,7 +144,11 @@
     ipaddr=$(set | grep "^SYSINFO_Network_Interface_.*_IPv4_Address" | head -n1 | cut -d'=' -f2)
 fi
 if [[ -n ${ipaddr} ]]; then
-    printf "${ipaddr}\t${hostname}\n" >> /etc/hosts
+    mydomain=`echo $CONFIG_ufds_admin_email | cut -d@ -f2`
+    if [ -n "$mydomain" ]; then
+        fullname="${hostname}.${mydomain}"
+    fi
+    printf "${ipaddr}\t${hostname} ${fullname}\n" >> /etc/hosts
 fi

 # Reset the library path now that we are past the critical stage
```