### PR TITLE
Fix /etc/profile in generic overlay after 3842

### DIFF
--- a/overlay/generic/etc/profile
+++ b/overlay/generic/etc/profile
@@ -29,8 +29,7 @@ export LOGNAME PATH
 
 if [ "$TERM" = "" ]
 then
-	if /bin/i386
-	then
+	if [ `uname -p` = "i386" ]; then
 		TERM=sun-color
 	else
 		TERM=sun


### PR DESCRIPTION
After illumos removed machid commands, I can see "bash: /bin/i386: No such file or directory" in freshly built smartos. This is caused by missing changes to /etc/profile in smartos-live. This PR fixes that.