### PR TITLE
imgadm create should work for non-cloned KVM VMs

### DIFF
--- a/src/img/lib/imgadm.js
+++ b/src/img/lib/imgadm.js
@@ -2811,14 +2811,12 @@ IMGADM.prototype.createImage = function createImage(options, callback) {
         function getVmInfo(next) {
             var opts;
             if (vmInfo.brand === 'kvm') {
-                if (vmInfo.disks) {
-                    for (var i = 0; i < vmInfo.disks.length; i++) {
-                        if (vmInfo.disks[i].image_uuid) {
-                            var disk = vmInfo.disks[i];
-                            opts = {uuid: disk.image_uuid, zpool: disk.zpool};
-                            vmZfsFilesystemName = disk.zfs_filesystem;
-                            break;
-                        }
+                if (vmInfo.disks && vmInfo.disks[0]) {
+                    var disk = vmInfo.disks[0];
+                    vmZfsFilesystemName = disk.zfs_filesystem;
+
+                    if (disk.image_uuid) {
+                        opts = {uuid: disk.image_uuid, zpool: disk.zpool};
                     }
                 }
             } else {


### PR DESCRIPTION
Fix for #407

With this changeset, imgadm create works on non-clone KVM VMs and allows us to create image from freshly installed virtual machine. This was discussed with @trentm.