### PR TITLE
Add conditional to SDC log upload

### DIFF
--- a/overlay/generic/etc/cron.d/crontabs/root
+++ b/overlay/generic/etc/cron.d/crontabs/root
@@ -7,7 +7,7 @@
 ## Delete saved core dumps over 7 days old
 15 0 * * * find /zones/*/cores -type f -mtime +7 -exec rm -f "{}" \;
 ## Delete logs to be uploaded over 7 days old if they aren't being consumed
-45 0 * * * find /var/log/sdc/upload/ -mount -maxdepth 1 -mindepth 1 -type f -mtime +7 -exec rm -f "{}" \;
+45 0 * * * [ -d /var/log/sdc/upload/ ] && find /var/log/sdc/upload/ -mount -maxdepth 1 -mindepth 1 -type f -mtime +7 -exec rm -f "{}" \;
 
 # NOTE: all entries above are in root's system-defined crontab; see the
 # crontab(1) man page.


### PR DESCRIPTION
This is SDC specific and causes problems on vanilla SmartOS.

This is also implemented in SDC-specific crontab (see https://github.com/joyent/sdc-platform/blob/8ba19f62f7c3e74f96303d0570ca403d7622f5ff/overlay/etc/cron.d/crontabs/root).

It may be more appropriate to remove this line completely from smartos-live. 
Since that is a potentially breaking change I did not go that route for this pull-request.

Relevant Github issue: #435