### PR TITLE
add total row to zonememstat(1)

### DIFF
--- a/overlay/generic/usr/sbin/zonememstat
+++ b/overlay/generic/usr/sbin/zonememstat
@@ -139,8 +139,15 @@ shift OPTIND-1
 
 [ $SUMMARY == 1 ] && do_proc
 
+if [ "`zonename`" = 'global' ]; then
+	gz=true
+else
+	gz=false
+fi
+
 kstat -c zone_memory_cap \
-    | nawk -v show_alias=${SHOW_ALIAS} -v zname=$ZONENAME -v over=$OVER 'BEGIN {
+    | nawk -v gz=$gz -v show_alias=${SHOW_ALIAS} -v zname=$ZONENAME -v over=$OVER \
+    'BEGIN {
 	if (show_alias == 1) {
 		alias_len = 12
 		while ("vmadm list -o zonename,alias -H" | getline) {
@@ -160,12 +167,17 @@ kstat -c zone_memory_cap \
     {
 	if ($1 == "nover") {
 		nover = $2
+		nover_t += nover
 	} else if ($1 == "pagedout") {
 		pout = $2 / 1048576
+		pout_t += pout
 	} else if ($1 == "physcap") {
 		cap = $2 / 1048576
+		if (cap < 2147483000)
+			cap_t += cap
 	} else if ($1 == "rss") {
 		rss = $2 / 1048576
+		rss_t += rss
 	} else if ($1 == "swap") {
 		swap = $2 / 1048576
 	} else if ($1 == "swapcap") {
@@ -195,4 +207,14 @@ kstat -c zone_memory_cap \
 				    $2, rss, cap, nover, pout);
 		}
 	}
+    }
+    END {
+	if (gz == "true" && zname == "ALL")
+		if (show_alias == 1)
+			printf("%37s %*s %8u %8u %8u %9u\n",
+			    "total", alias_len, "-", rss_t, cap_t,
+			    nover_t, pout_t);
+		else
+			printf("%37s %8u %8u %8u %9u\n",
+			    "total", rss_t, cap_t, nover_t, pout_t);
 }'


### PR DESCRIPTION
adds a `total` column to `zonememstat(1)`

```
# ./zonememstat 
                                 ZONE  RSS(MB)  CAP(MB)    NOVER  POUT(MB)
                               global        0        -        -         -
 9d4f2dba-583f-4d26-9910-9c455ec0b90a      483     4096        0         0
 273948b9-917e-468a-ad19-3f61dcb8366f       80      256        0         0
 b5dc00a8-7737-43cd-a842-0afe0c6dddd5      298     2048        0         0
 be54bfae-154c-4abd-823f-634d630b41f0      184     1024        0         0
 06c4cece-5318-4745-86ca-039478e2f609       51      256        0         0
 043a1e7d-6e60-4014-9ea5-7cfc48bf784b       38     4096        0         0
 9ac8adbe-8430-4c2e-bb67-f893830596d2       86      512        0         0
 9f5ece6c-e6d8-42da-a7a4-7a6dc8157a71       53      512        0         0
 68f4c4e0-d981-471f-97ed-c5acdbfdf666       52      512        0         0
                                total     1329    13312        0         0
```

only is shown when `zonememstat(1)` is 1. run from the global zone and 2. run without a `-z <zone>` argument