### PR TITLE
OS-5062 VM.load should use "zfs list -r" where possible

### DIFF
--- a/src/vm/node_modules/vmload/index.js
+++ b/src/vm/node_modules/vmload/index.js
@@ -1132,6 +1132,7 @@ function loadDatasetObjects(uuid, cache, options, callback)
 {
     var log;
     var start_time;
+    var obj;
 
     log = options.log; // caller has asserted
 
@@ -1149,9 +1150,18 @@ function loadDatasetObjects(uuid, cache, options, callback)
         return;
     }
 
-    var obj;
+    obj = {};
+    if (uuid && cache.zonexml_objects && cache.zonexml_objects[uuid]) {
+        var zonexml = cache.zonexml_objects[uuid];
+        Object.keys(zonexml).forEach(function (k) {
+            obj[k] = zonexml[k];
+        });
+    }
     if (uuid && cache.zoneadm_objects && cache.zoneadm_objects[uuid]) {
-        obj = cache.zoneadm_objects[uuid];
+        var zoneadm = cache.zoneadm_objects[uuid];
+        Object.keys(zoneadm).forEach(function (k) {
+            obj[k] = zoneadm[k];
+        });
     }
 
     start_time = (new Date).getTime();

--- a/src/vm/node_modules/vmload/index.js
+++ b/src/vm/node_modules/vmload/index.js
@@ -1149,9 +1149,14 @@ function loadDatasetObjects(uuid, cache, options, callback)
         return;
     }
 
+    var obj;
+    if (uuid && cache.zoneadm_objects && cache.zoneadm_objects[uuid]) {
+        obj = cache.zoneadm_objects[uuid];
+    }
+
     start_time = (new Date).getTime();
 
-    getDatasets(options, function (err, results) {
+    getDatasets(uuid, obj, options, function (err, results) {
 
         log.debug('loading dataset_objects took '
             + ((new Date).getTime() - start_time) + ' ms');

--- a/src/vm/node_modules/vmload/vmload-datasets.js
+++ b/src/vm/node_modules/vmload/vmload-datasets.js
@@ -178,7 +178,7 @@ function cleanDatasetObject(obj)
     }
 }
 
-function getDatasets(options, callback)
+function getDatasets(uuid, obj, options, callback)
 {
     var fields;
     var log;
@@ -261,6 +261,20 @@ function getDatasets(options, callback)
         log: log,
         types: zfs_types
     };
+    /*
+     * If this is about one specific zone, and it's a smartos/lx zone, we only
+     * need to do our zfs list recursively under the zone's dataset.
+     *
+     * This saves a lot of time on machines with lots of zfs datasets and snaps.
+     */
+    if (uuid && ['joyent', 'joyent-minimal', 'lx'].indexOf(obj.brand) !== -1) {
+        /*
+         * The zonepath property is always of the form '/' + zfs_filesystem,
+         * as this is how it is built in createZone().
+         */
+        var topzfs = obj.zonepath.slice(1);
+        _options.parent = topzfs;
+    }
     if (options.hasOwnProperty('spawnZfs')) {
         _options.spawnZfs = options.spawnZfs;
     }
@@ -288,6 +302,9 @@ function getZfsList(options, callback) {
     if (options.hasOwnProperty('spawnZfs')) {
         task.spawnZfs = options.spawnZfs;
     }
+    if (options.hasOwnProperty('parent')) {
+        task.parent = options.parent;
+    }
 
     try {
         zfs_list_in_progress[task].on('result', callback);
@@ -308,16 +325,49 @@ function getZfsList(options, callback) {
     }
 }
 
+function makeEnv() {
+    var env = {};
+    var names = Object.keys(process.env);
+
+    for (var i = 0; i < names.length; i++) {
+        var name = names[i];
+
+        if (name === 'LANG' || name.match(/^LC_/)) {
+            /*
+             * Do not copy any locale variables into the child environment.
+             * See environ(5) for more information about what these variables
+             * mean.
+             */
+            continue;
+        }
+
+        env[name] = process.env[name];
+    }
+
+    /*
+     * Force the POSIX locale so that error messages are presented
+     * consistently.
+     */
+    env.LANG = env.LC_ALL = 'C';
+
+    return (env);
+}
+
 function zfs(options, cmd, args, lineHandler, callback)
 {
     var buffer = '';
+    var errbuffer = '';
     var line_count = 0;
     var lines;
     var log = options.log;
     var zfs_child;
+    var gotNotExist = false;
 
     log.debug({cmdline: cmd + ' ' + args.join(' ')}, 'executing zfs');
-    zfs_child = spawn(cmd, args, {stdio: 'pipe'});
+    zfs_child = spawn(cmd, args, {
+        stdio: 'pipe',
+        env: makeEnv()
+    });
     log.debug('zfs[' + zfs_child.pid + '] running');
 
     zfs_child.stdout.on('data', function (data) {
@@ -337,8 +387,17 @@ function zfs(options, cmd, args, lineHandler, callback)
 
     // we don't expect data on stderr, so treat as a warning
     zfs_child.stderr.on('data', function (data) {
-        log.warn({stderr: data.toString()}, 'zfs[' + zfs_child.pid + '] wrote '
-            + 'output to stderr.');
+        errbuffer += data.toString();
+        var elines = errbuffer.split('\n');
+        while (elines.length > 1) {
+            var line = elines.shift();
+            if (line.indexOf('dataset does not exist') !== -1) {
+                gotNotExist = true;
+            }
+            log.warn({stderr: line}, 'zfs[' + zfs_child.pid + '] wrote '
+                + 'output to stderr.');
+        }
+        errbuffer = elines[0];
     });
 
     // doesn't take input.
@@ -349,6 +408,13 @@ function zfs(options, cmd, args, lineHandler, callback)
         log.debug('zfs[' + zfs_child.pid + '] exited with code: ' + code
             + ' (' + line_count + ' lines to stdout)');
         if (code === 0) {
+            callback();
+        } else if (code === 1 && options.hasOwnProperty('parent') && gotNotExist) {
+            /*
+             * When we're recursively listing under a parent dataset, and
+             * that dataset doesn't exist yet, emulate the behaviour of
+             * a filtered "list everything" -- ie, return ok
+             */
             callback();
         } else {
             callback(new Error('zfs exited prematurely with code: ' + code));
@@ -444,6 +510,10 @@ function zfsList(options, callback) {
     });
 
     args = ['list', '-H', '-p', '-t', types.join(','), '-o', fields.join(',')];
+    if (options.hasOwnProperty('parent')) {
+        args.push('-r');
+        args.push(options.parent);
+    }
 
     /*
      * Allow mocking out the zfs call. If options includes a 'spawnZfs' function
@@ -490,6 +560,9 @@ zfs_list_queue = async.queue(function (task, callback) {
     };
     if (task.hasOwnProperty('spawnZfs')) {
         options.spawnZfs = task.spawnZfs;
+    }
+    if (task.hasOwnProperty('parent')) {
+        options.parent = task.parent;
     }
 
     zfsList(options, function (err, data) {

--- a/src/vm/node_modules/vmload/vmload-datasets.js
+++ b/src/vm/node_modules/vmload/vmload-datasets.js
@@ -185,6 +185,7 @@ function getDatasets(uuid, obj, options, callback)
     var _options = {};
     var zfs_fields = [];
     var zfs_types = [];
+    var result, listEverything, parents;
 
     fields = options.fields;
     log = options.log;
@@ -252,6 +253,16 @@ function getDatasets(uuid, obj, options, callback)
     }
 
     /*
+     * In case we have to do multiple zfs list commands, we want to add their
+     * results together in one place. Create an empty results object and give
+     * it to each of them to add their lines to.
+     */
+    result = {
+        datasets: {},
+        mountpoints: {},
+        snapshots: {}
+    };
+    /*
      * Note that 'fields' here is the *zfs* fields and not the VM object
      * fields. That's why we can't just pass the options we were given through
      * and instead build a new one.
@@ -259,27 +270,69 @@ function getDatasets(uuid, obj, options, callback)
     _options = {
         fields: zfs_fields,
         log: log,
-        types: zfs_types
+        types: zfs_types,
+        results: result
     };
+
+    listEverything = false;
+    parents = [];
+
     /*
-     * If this is about one specific zone, and it's a smartos/lx zone, we only
-     * need to do our zfs list recursively under the zone's dataset.
-     *
-     * This saves a lot of time on machines with lots of zfs datasets and snaps.
+     * The zonepath property is always of the form '/' + zfs_filesystem,
+     * as this is how it is built in createZone().
      */
-    if (uuid && ['joyent', 'joyent-minimal', 'lx'].indexOf(obj.brand) !== -1) {
+    if (obj.zonepath) {
+        assert.strictEqual(obj.zonepath[0], '/');
+        parents.push(obj.zonepath.slice(1));
+
+    } else {
         /*
-         * The zonepath property is always of the form '/' + zfs_filesystem,
-         * as this is how it is built in createZone().
+         * If we don't have one we're listing all VMs and need to fetch
+         * everything anyway.
          */
-        var topzfs = obj.zonepath.slice(1);
-        _options.parent = topzfs;
+        listEverything = true;
     }
+
+    if (obj.datasets) {
+        obj.datasets.forEach(function (ds) {
+            parents.push(ds);
+        });
+    }
+
+    if (obj.disks) {
+        obj.disks.forEach(function (ds) {
+            /*
+             * If we have even one disk that we can't recognise as a zvol,
+             * then give up and "zfs list" everything on the system.
+             */
+            var m = ds.path.match(/^\/dev\/zvol\/r?dsk\/(.+)$/);
+            if (m && m[1]) {
+                parents.push(m[1]);
+            } else {
+                listEverything = true;
+            }
+        });
+    }
+
     if (options.hasOwnProperty('spawnZfs')) {
         _options.spawnZfs = options.spawnZfs;
     }
 
-    getZfsList(_options, callback);
+    if (listEverything) {
+        getZfsList(_options, callback);
+
+    } else {
+        async.eachSeries(parents, function (parent, cb) {
+            _options.parent = parent;
+            getZfsList(_options, cb);
+        }, function (err) {
+            if (err) {
+                callback(err);
+                return;
+            }
+            callback(null, result);
+        });
+    }
 }
 
 function getZfsList(options, callback) {
@@ -305,6 +358,9 @@ function getZfsList(options, callback) {
     if (options.hasOwnProperty('parent')) {
         task.parent = options.parent;
     }
+    if (options.hasOwnProperty('results')) {
+        task.results = options.results;
+    }
 
     try {
         zfs_list_in_progress[task].on('result', callback);
@@ -328,9 +384,11 @@ function getZfsList(options, callback) {
 function makeEnv() {
     var env = {};
     var names = Object.keys(process.env);
+    var name;
+    var i;
 
-    for (var i = 0; i < names.length; i++) {
-        var name = names[i];
+    for (i = 0; i < names.length; i++) {
+        name = names[i];
 
         if (name === 'LANG' || name.match(/^LC_/)) {
             /*
@@ -387,10 +445,11 @@ function zfs(options, cmd, args, lineHandler, callback)
 
     // we don't expect data on stderr, so treat as a warning
     zfs_child.stderr.on('data', function (data) {
+        var elines, line;
         errbuffer += data.toString();
-        var elines = errbuffer.split('\n');
+        elines = errbuffer.split('\n');
         while (elines.length > 1) {
-            var line = elines.shift();
+            line = elines.shift();
             if (line.indexOf('dataset does not exist') !== -1) {
                 gotNotExist = true;
             }
@@ -404,12 +463,18 @@ function zfs(options, cmd, args, lineHandler, callback)
     zfs_child.stdin.end();
 
     zfs_child.on('close', function (code) {
+        /* In case there's a partial line leftover with no newline. */
+        if (errbuffer.length > 0) {
+            log.warn({stderr: errbuffer}, 'zfs[' + zfs_child.pid + '] wrote '
+                + 'output to stderr.');
+        }
 
         log.debug('zfs[' + zfs_child.pid + '] exited with code: ' + code
             + ' (' + line_count + ' lines to stdout)');
         if (code === 0) {
             callback();
-        } else if (code === 1 && options.hasOwnProperty('parent') && gotNotExist) {
+        } else if (code === 1 && options.hasOwnProperty('parent')
+            && gotNotExist) {
             /*
              * When we're recursively listing under a parent dataset, and
              * that dataset doesn't exist yet, emulate the behaviour of
@@ -481,11 +546,16 @@ function zfsList(options, callback) {
         + typeof (fields));
     assert(log, 'no logger passed to zfsList()');
 
-    results = {
-        datasets: {},
-        mountpoints: {},
-        snapshots: {}
-    };
+    results = options.results;
+    if (results === undefined || typeof (results) !== 'object'
+        || typeof (results.datasets) !== 'object') {
+
+        results = {
+            datasets: {},
+            mountpoints: {},
+            snapshots: {}
+        };
+    }
 
     // Called when the `zfs` command or its mock completes
     function callbackHandler(err) {
@@ -563,6 +633,9 @@ zfs_list_queue = async.queue(function (task, callback) {
     }
     if (task.hasOwnProperty('parent')) {
         options.parent = task.parent;
+    }
+    if (task.hasOwnProperty('results')) {
+        options.results = task.results;
     }
 
     zfsList(options, function (err, data) {

--- a/src/vm/tests/test-vmload-datasets.js
+++ b/src/vm/tests/test-vmload-datasets.js
@@ -43,7 +43,7 @@ function getDatasetsWrapper(fields, lines, out, callback)
         spawnZfs: spawnZfs
     };
 
-    getDatasets(options, callback);
+    getDatasets(undefined, {}, options, callback);
 }
 
 test('test with no datasets', function (t) {


### PR DESCRIPTION
Currently, calling VM.load on one specific zone causes it to do a "zfs list" on all datasets and snapshots on the entire system. When we already know the zone is of the `joyent[-minimal]` or `lx` brands, we don't have to do this, as we can safely assume all the related datasets are under the zone's root dataset as children. So we can use `zfs list -r` and not have to walk the entire pool.

This makes `VM.load` (and thus `vmadm get` and also the SDC heartbeating) faster on systems with many ZFS datasets. It also reduces the CPU load generated by regular heartbeats and lock contention.

For example, on one of my CNs, before this patch:

```
[root@a0-36-9f-29-7b-f4 (gps-1) ~]# time vmadm get $uuid >/dev/null
real	0m1.679s
user	0m0.787s
sys	0m0.907s
[root@a0-36-9f-29-7b-f4 (gps-1) ~]# time vmadm get $uuid >/dev/null
real	0m1.655s
user	0m0.789s
sys	0m0.882s
[root@a0-36-9f-29-7b-f4 (gps-1) ~]# time vmadm get $uuid >/dev/null
real	0m1.680s
user	0m0.786s
sys	0m0.910s
```

And after this patch:

```
[root@a0-36-9f-29-7b-f4 (gps-1) ~]# time vmadm get $uuid >/dev/null
real	0m0.868s
user	0m0.456s
sys	0m0.409s
[root@a0-36-9f-29-7b-f4 (gps-1) ~]# time vmadm get $uuid >/dev/null
real	0m0.864s
user	0m0.456s
sys	0m0.406s
[root@a0-36-9f-29-7b-f4 (gps-1) ~]# time vmadm get $uuid >/dev/null
real	0m0.910s
user	0m0.475s
sys	0m0.414s
```