### PR TITLE
Globalzone IPv6 support

### DIFF
--- a/overlay/generic/lib/svc/method/net-physical
+++ b/overlay/generic/lib/svc/method/net-physical
@@ -405,6 +405,16 @@ if smf_is_globalzone; then
         admin_netmask=${BOOT_admin_netmask}
     fi
 
+    admin_ip6=${CONFIG_admin_ip6}
+    if [[ -z "$admin_ip6" ]]; then
+        admin_ip6=${BOOT_admin_ip6}
+    fi
+
+    admin_netmask6=${CONFIG_admin_netmask6}
+    if [[ -z "$admin_netmask6" ]]; then
+        admin_netmask6=${BOOT_admin_netmask6}
+    fi
+
     if [[ -n ${admin_ip} ]] && [[ -n ${admin_netmask} ]];
     then
         /sbin/ifconfig ${SYSINFO_NIC_admin} inet ${admin_ip} \
@@ -444,6 +454,31 @@ if smf_is_globalzone; then
 
             ADMIN_NIC_UP=true
         fi
+    fi
+
+    if [[ -n ${admin_ip6} ]]; then
+        # NOTE: plumbing the interface for IPv6 also implicitly sets a
+        # default gateway, this is due to in.ndpd and can't be disabled
+        if [[ -n ${admin_ip6} ]] && [[ -n ${admin_netmask6} ]]; then
+            # Plumb interface for inet6
+            ifconfig ${SYSINFO_NIC_admin} inet6 plumb up
+
+            # Configure static IPv6
+            /sbin/ifconfig ${SYSINFO_NIC_admin} inet6 \
+                addif ${admin_ip6}/${admin_netmask6} up
+            ADMIN_NIC_UP=true
+        else
+            if [[ ${admin_ip6} == "auto" ]]; then
+                # Plumb interface for inet6
+                ifconfig ${SYSINFO_NIC_admin} inet6 plumb up
+
+                # Autodiscovery IPv6 using SLAAC
+                # in.ndpd will be started later, we just need to plumb the interface
+                ADMIN_NIC_UP=true
+            fi
+        fi
+
+        # don't setup resolv.conf, IPv6 addresses already work
     fi
 
     # If on Parallels or VirtualBox, create a bridge which

--- a/overlay/generic/lib/svc/method/net-physical
+++ b/overlay/generic/lib/svc/method/net-physical
@@ -219,6 +219,7 @@ function vnic_up
     fi
     eval "vnic_${iface}_up=true"
 }
+
 function vnic_up6
 {
     set -o xtrace

--- a/overlay/generic/lib/svc/method/net-physical
+++ b/overlay/generic/lib/svc/method/net-physical
@@ -226,16 +226,15 @@ function vnic_up6
     typeset link="$1"
     typeset iface="$2"
     typeset ip="$3"
-    typeset netmask="$4"
-    typeset vlan_id="$5"
-    typeset mac_addr="$6"
-    typeset mtu="$7"
-    typeset details="link='${link}', iface='${iface}', ip='${ip}', netmask='${netmask}, vlan_id='${vlan_id}'"
+    typeset vlan_id="$4"
+    typeset mac_addr="$5"
+    typeset mtu="$6"
+    typeset details="link='${link}', iface='${iface}', ip6='${ip}', vlan_id='${vlan_id}'"
     typeset vlan_opt=
     typeset mac_addr_opt=
     typeset prop_opt=
 
-    if [[ -z ${link} ]] || [[ -z ${iface} ]] || [[ -z ${ip} ]] || ([[ ${ip} != "addrconf" ]] && [[ -z ${netmask} ]]); then
+    if [[ -z ${link} ]] || [[ -z ${iface} ]] || [[ -z ${ip} ]]; then
         echo "WARNING: not bringing up nic (insufficient configuration): $details"
         return
     fi
@@ -278,12 +277,12 @@ function vnic_up6
         exit $SMF_EXIT_ERR_FATAL
     fi
 
-    if [[ -n ${ip} && -n ${netmask} ]] || [[ ${ip} == 'addrconf' ]]; then
+    if [[ -n ${ip} ]]; then
         /sbin/ifconfig ${iface} inet6 up
     fi
-    if [[ -n ${ip} ]] && [[ -n ${netmask} ]]; then
+    if [[ ${ip} != "addrconf" ]]; then
         /sbin/ifconfig ${iface} inet6 \
-            addif ${ip}/${netmask} preferred up
+            addif ${ip} preferred up
     fi
     eval "vnic_${iface}_up=true"
 }
@@ -493,11 +492,6 @@ if smf_is_globalzone; then
         admin_ip6=${BOOT_admin_ip6}
     fi
 
-    admin_netmask6=${CONFIG_admin_netmask6}
-    if [[ -z "$admin_netmask6" ]]; then
-        admin_netmask6=${BOOT_admin_netmask6}
-    fi
-
     if [[ -n ${admin_ip} ]] && [[ -n ${admin_netmask} ]];
     then
         /sbin/ifconfig ${SYSINFO_NIC_admin} inet ${admin_ip} \
@@ -539,7 +533,7 @@ if smf_is_globalzone; then
         fi
     fi
 
-    if [[ -n ${admin_ip6} && -n ${admin_netmask6} ]] || [[ ${admin_ip6} == 'addrconf' ]]; then
+    if [[ -n ${admin_ip6} ]]; then
         # Plumb interface for inet6
         ifconfig ${SYSINFO_NIC_admin} inet6 plumb up
 
@@ -553,7 +547,7 @@ if smf_is_globalzone; then
         # Configure static IPv6
         if [[ ${admin_ip6} != "addrconf" ]]; then
             /sbin/ifconfig ${SYSINFO_NIC_admin} inet6 \
-                addif ${admin_ip6}/${admin_netmask6} preferred up
+                addif ${admin_ip6} preferred up
         fi
 
         ADMIN_NIC_UP=true
@@ -590,7 +584,7 @@ if smf_is_globalzone; then
 
         if [[ ${do_setup_external} == "yes" ]] && [[ -n "${CONFIG_external_ip6}" ]]; then
             vnic_up6 "${SYSINFO_NIC_external}" "external0" \
-                "${CONFIG_external_ip6}" "${CONFIG_external_netmask6}" \
+                "${CONFIG_external_ip6}" \
                 "${CONFIG_external_vlan_id}" "${CONFIG_external_mac}" \
                 "${CONFIG_external_mtu}"
         fi
@@ -658,13 +652,12 @@ if smf_is_globalzone; then
                     iface=${key//_i6p/}
                     #echo "   iface=$iface"
                     eval "ip=\${CONFIG_${iface}_ip6}"
-                    eval "netmask=\${CONFIG_${iface}_netmask6}"
                     eval "vlan=\${CONFIG_${iface}_vlan_id}"
                     eval "macaddr=\${CONFIG_${iface}_mac}"
                     eval "mtu=\${CONFIG_${iface}_mtu}"
 
-                    echo vnic_up6 "${link}" "${iface}" "${ip}" "${netmask}" "${vlan}" "${macaddr}" "${mtu}"
-                    vnic_up6 "${link}" "${iface}" "${ip}" "${netmask}" \
+                    echo vnic_up6 "${link}" "${iface}" "${ip}" "${vlan}" "${macaddr}" "${mtu}"
+                    vnic_up6 "${link}" "${iface}" "${ip}" \
                         "${vlan}" "${macaddr}" "${mtu}"
                 fi
             done
@@ -673,12 +666,11 @@ if smf_is_globalzone; then
                 if [[ ${key} == ${tag}[0-9]-ip6 ]] || [[ ${key} == ${tag}[0-9][0-9]-ip6 ]]; then
                     iface=${key//-ip6/}
                     eval "ip=\${BOOT_${iface}_ip6}"
-                    eval "netmask=\${BOOT_${iface}_netmask6}"
                     eval "vlan=\${BOOT_${iface}_vlan_id}"
                     eval "macaddr=\${BOOT_${iface}_mac}"
                     eval "mtu=\${CONFIG_${iface}_mtu}"
-                    echo vnic_up6 "${link}" "${iface}" "${ip}" "${netmask}" "${vlan}" "${macaddr}" "${mtu}"
-                    vnic_up6 "${link}" "${iface}" "${ip}" "${netmask}" \
+                    echo vnic_up6 "${link}" "${iface}" "${ip}" "${vlan}" "${macaddr}" "${mtu}"
+                    vnic_up6 "${link}" "${iface}" "${ip}" \
                         "${vlan}" "${macaddr}" "${mtu}"
                 fi
             done

--- a/overlay/generic/lib/svc/method/net-physical
+++ b/overlay/generic/lib/svc/method/net-physical
@@ -155,13 +155,18 @@ function vnic_up
     typeset mac_addr="$6"
     typeset dhcp_primary="$7"
     typeset mtu="$8"
-    typeset details="link='${link}', iface='${iface}', ip='${ip}', netmask='${netmask}, vlan_id='${vlan_id}'"
+    typeset details=
     typeset vlan_opt=
     typeset mac_addr_opt=
     typeset prop_opt=
 
-    if [[ -z ${link} ]] || [[ -z ${iface} ]] || [[ -z ${ip} ]] || ([[ ${ip} != "dhcp" ]] && [[ -z ${netmask} ]]); then
-        echo "WARNING: not bringing up nic (insufficient configuration): $details"
+    details="link='${link}', iface='${iface}', ip='${ip}'"
+    details="${details}, netmask='${netmask}, vlan_id='${vlan_id}'"
+
+    if [[ -z ${link} ]] || [[ -z ${iface} ]] || \
+       [[ -z ${ip} ]] || ([[ ${ip} != "dhcp" ]] && [[ -z ${netmask} ]]); then
+        echo "WARNING: not bringing up nic (insufficient configuration): " \
+             "$details"
         return
     fi
 
@@ -173,7 +178,8 @@ function vnic_up
 
     if [[ -n ${mac_addr} ]] && [[ -n ${ActiveAggrLinks[${mac_addr}]} ]]; then
         echo "WARNING: trying to assign MAC address \"${mac_addr}\" to vnic," \
-            " but it already belongs to link aggr \"${ActiveAggrLinks[${mac_addr}]}\""
+            " but it already belongs to link aggr " \
+            "\"${ActiveAggrLinks[${mac_addr}]}\""
         return
     fi
 
@@ -231,19 +237,24 @@ function vnic_up6
     typeset vlan_id="$4"
     typeset mac_addr="$5"
     typeset mtu="$6"
-    typeset details="link='${link}', iface='${iface}', ip6='${ip}', vlan_id='${vlan_id}'"
+    typeset details=
     typeset vlan_opt=
     typeset mac_addr_opt=
     typeset prop_opt=
 
+    details="link='${link}', iface='${iface}', ip6='${ip}'"
+    details="${details}, vlan_id='${vlan_id}'"
+
     if [[ -z ${link} ]] || [[ -z ${iface} ]] || [[ -z ${ip} ]]; then
-        echo "WARNING: not bringing up nic (insufficient configuration): $details"
+        echo "WARNING: not bringing up nic (insufficient configuration): " \
+             "$details"
         return
     fi
 
     if [[ -n ${mac_addr} ]] && [[ -n ${ActiveAggrLinks[${mac_addr}]} ]]; then
         echo "WARNING: trying to assign MAC address \"${mac_addr}\" to vnic," \
-            " but it already belongs to link aggr \"${ActiveAggrLinks[${mac_addr}]}\""
+            " but it already belongs to link aggr " \
+            "\"${ActiveAggrLinks[${mac_addr}]}\""
         return
     fi
 

--- a/overlay/generic/lib/svc/method/net-physical
+++ b/overlay/generic/lib/svc/method/net-physical
@@ -142,7 +142,7 @@ function plumb_admin
     wait_for_admin_nic_state "up"
 }
 
-# Creates, plumbs and brings up a vnic with the specified parameters
+# Creates, plumbs and brings up a vnic with the specified inet parameters
 function vnic_up
 {
     set -o xtrace
@@ -220,6 +220,7 @@ function vnic_up
     eval "vnic_${iface}_up=true"
 }
 
+# Creates, plumbs and brings up a vnic with the specified inet6 parameters
 function vnic_up6
 {
     set -o xtrace

--- a/overlay/generic/lib/svc/method/net-physical
+++ b/overlay/generic/lib/svc/method/net-physical
@@ -278,8 +278,25 @@ function set_default_route
         default_gw=${CONFIG_external_gateway}
     fi
 
+    if [[ -n ${CONFIG_admin_gateway6} ]]; then
+        default_gw6="${CONFIG_admin_gateway6}"
+
+    elif [[ -n ${BOOT_admin_gateway6} ]]; then
+        default_gw6=${BOOT_admin_gateway6}
+
+    elif [[ -n ${CONFIG_external_gateway6} ]]; then
+        default_gw6=${CONFIG_external_gateway6}
+    fi
+
     if [[ -n ${default_gw} ]]; then
         echo "${default_gw}" > /etc/defaultrouter
+    fi
+
+    if [[ -n ${default_gw6} ]]; then
+        # flush existing autoconfigured default routes
+        /usr/sbin/route flush -inet6
+        # add static route
+        /usr/sbin/route add -inet6 default ${default_gw6}
     fi
 }
 

--- a/overlay/generic/lib/svc/method/net-physical
+++ b/overlay/generic/lib/svc/method/net-physical
@@ -349,6 +349,21 @@ function set_default_route
     if [[ -n ${default_gw} ]]; then
         echo "${default_gw}" > /etc/defaultrouter
     fi
+
+    if [[ -n ${CONFIG_admin_gateway6} ]]; then
+        default_gw6="${CONFIG_admin_gateway6}"
+
+    elif [[ -n ${BOOT_admin_gateway6} ]]; then
+        default_gw6=${BOOT_admin_gateway6}
+
+    elif [[ -n ${CONFIG_external_gateway6} ]]; then
+        default_gw6=${CONFIG_external_gateway6}
+    fi
+
+    if [[ -n ${default_gw6} ]]; then
+        # add static route
+        /usr/sbin/route add -inet6 default ${default_gw6}
+    fi
 }
 
 #

--- a/overlay/generic/lib/svc/method/net-physical
+++ b/overlay/generic/lib/svc/method/net-physical
@@ -278,7 +278,7 @@ function vnic_up6
         exit $SMF_EXIT_ERR_FATAL
     fi
 
-    if [[ -n $ip && -n $netmask ]] || [[ $ip == 'auto' ]]; then
+    if [[ -n ${ip} && -n ${netmask} ]] || [[ ${ip} == 'auto' ]]; then
         /sbin/ifconfig ${iface} inet6 up
     fi
     if [[ -n ${ip} ]] && [[ -n ${netmask} ]]; then
@@ -539,7 +539,7 @@ if smf_is_globalzone; then
         fi
     fi
 
-    if [[ -n $admin_ip6 && -n $admin_netmask6 ]] || [[ $admin_ip6 == 'auto' ]]; then
+    if [[ -n ${admin_ip6} && -n ${admin_netmask6} ]] || [[ ${admin_ip6} == 'auto' ]]; then
         # Plumb interface for inet6
         ifconfig ${SYSINFO_NIC_admin} inet6 plumb up
 

--- a/overlay/generic/lib/svc/method/net-physical
+++ b/overlay/generic/lib/svc/method/net-physical
@@ -574,28 +574,24 @@ if smf_is_globalzone; then
     fi
 
     # Setup external NIC
-    if [[ -n ${SYSINFO_NIC_external} ]] && [[ -n "${CONFIG_external_ip}" ]]; then
+    if [[ -n ${SYSINFO_NIC_external} ]]; then
         #
         # The installer may have set up external0, so if it already
         # exists, we're not going to try and set up the vnic again.
         #
-        do_external=
+        do_setup_external="no"
         if ! dladm show-vnic external0 > /dev/null; then
-            do_external="yes"
+            do_setup_external="yes"
         fi
-        if [[ ${do_external} == "yes" ]]; then
+
+        if [[ ${do_setup_external} == "yes" ]] && [[ -n "${CONFIG_external_ip}" ]]; then
             vnic_up "${SYSINFO_NIC_external}" "external0" \
                 "${CONFIG_external_ip}" "${CONFIG_external_netmask}" \
                 "${CONFIG_external_vlan_id}" "${CONFIG_external_mac}" \
                 "primary" "${CONFIG_external_mtu}"
         fi
-    fi
-    if [[ -n ${SYSINFO_NIC_external} ]] && [[ -n "${CONFIG_external_ip6}" ]]; then
-        #
-        # The installer may have set up external0, so if it already
-        # exists, we're not going to try and set up the vnic again.
-        #
-        if [[ ${do_external} == "yes" ]]; then
+
+        if [[ ${do_setup_external} == "yes" ]] && [[ -n "${CONFIG_external_ip6}" ]]; then
             vnic_up6 "${SYSINFO_NIC_external}" "external0" \
                 "${CONFIG_external_ip6}" "${CONFIG_external_netmask6}" \
                 "${CONFIG_external_vlan_id}" "${CONFIG_external_mac}" \

--- a/overlay/generic/lib/svc/method/net-physical
+++ b/overlay/generic/lib/svc/method/net-physical
@@ -235,7 +235,7 @@ function vnic_up6
     typeset mac_addr_opt=
     typeset prop_opt=
 
-    if [[ -z ${link} ]] || [[ -z ${iface} ]] || [[ -z ${ip} ]] || ([[ ${ip} != "auto" ]] && [[ -z ${netmask} ]]); then
+    if [[ -z ${link} ]] || [[ -z ${iface} ]] || [[ -z ${ip} ]] || ([[ ${ip} != "addrconf" ]] && [[ -z ${netmask} ]]); then
         echo "WARNING: not bringing up nic (insufficient configuration): $details"
         return
     fi
@@ -278,7 +278,7 @@ function vnic_up6
         exit $SMF_EXIT_ERR_FATAL
     fi
 
-    if [[ -n ${ip} && -n ${netmask} ]] || [[ ${ip} == 'auto' ]]; then
+    if [[ -n ${ip} && -n ${netmask} ]] || [[ ${ip} == 'addrconf' ]]; then
         /sbin/ifconfig ${iface} inet6 up
     fi
     if [[ -n ${ip} ]] && [[ -n ${netmask} ]]; then
@@ -539,7 +539,7 @@ if smf_is_globalzone; then
         fi
     fi
 
-    if [[ -n ${admin_ip6} && -n ${admin_netmask6} ]] || [[ ${admin_ip6} == 'auto' ]]; then
+    if [[ -n ${admin_ip6} && -n ${admin_netmask6} ]] || [[ ${admin_ip6} == 'addrconf' ]]; then
         # Plumb interface for inet6
         ifconfig ${SYSINFO_NIC_admin} inet6 plumb up
 
@@ -551,7 +551,7 @@ if smf_is_globalzone; then
         #       in.ndpd also sets a default route and this can't be disabled.
 
         # Configure static IPv6
-        if [[ ${admin_ip6} != "auto" ]]; then
+        if [[ ${admin_ip6} != "addrconf" ]]; then
             /sbin/ifconfig ${SYSINFO_NIC_admin} inet6 \
                 addif ${admin_ip6}/${admin_netmask6} preferred up
         fi

--- a/overlay/generic/lib/svc/method/net-physical
+++ b/overlay/generic/lib/svc/method/net-physical
@@ -649,7 +649,7 @@ if smf_is_globalzone; then
 
             for key in ${config_ip6_keys}; do
                 if [[ ${key} == ${tag}[0-9]_ip6 ]] || [[ ${key} == ${tag}[0-9][0-9]_ip6 ]]; then
-                    iface=${key//_i6p/}
+                    iface=${key//_ip6/}
                     #echo "   iface=$iface"
                     eval "ip=\${CONFIG_${iface}_ip6}"
                     eval "vlan=\${CONFIG_${iface}_vlan_id}"

--- a/overlay/generic/lib/svc/method/net-physical
+++ b/overlay/generic/lib/svc/method/net-physical
@@ -278,7 +278,7 @@ function vnic_up6
         exit $SMF_EXIT_ERR_FATAL
     fi
 
-    if [[ ${ip} == "auto" ]] || [[ -n ${ip} ]] && [[ -n ${netmask} ]]; then
+    if [[ -n $ip && -n $netmask ]] || [[ $ip == 'auto' ]]; then
         /sbin/ifconfig ${iface} inet6 up
     fi
     if [[ -n ${ip} ]] && [[ -n ${netmask} ]]; then
@@ -539,27 +539,24 @@ if smf_is_globalzone; then
         fi
     fi
 
-    if [[ -n ${admin_ip6} ]]; then
-        # NOTE: plumbing the interface for IPv6 also implicitly sets a
-        # default gateway, this is due to in.ndpd and can't be disabled
-        if [[ -n ${admin_ip6} ]] && [[ -n ${admin_netmask6} ]]; then
-            # Plumb interface for inet6
-            ifconfig ${SYSINFO_NIC_admin} inet6 plumb up
+    if [[ -n $ip && -n $netmask ]] || [[ $ip == 'auto' ]]; then
+        # Plumb interface for inet6
+        ifconfig ${SYSINFO_NIC_admin} inet6 plumb up
 
-            # Configure static IPv6
+        # Autodiscovery IPv6 using SLAAC
+        # NOTE: in.ndpd will be started later, due to plumbing the interface.
+        #       this means autodiscovery also happens when configuring a 
+        #       static address.
+        #
+        #       in.ndpd also sets a default route and this can't be disabled.
+
+        # Configure static IPv6
+        if [[ ${admin_ip6} != "auto" ]]; then
             /sbin/ifconfig ${SYSINFO_NIC_admin} inet6 \
                 addif ${admin_ip6}/${admin_netmask6} preferred up
-            ADMIN_NIC_UP=true
-        else
-            if [[ ${admin_ip6} == "auto" ]]; then
-                # Plumb interface for inet6
-                ifconfig ${SYSINFO_NIC_admin} inet6 plumb up
-
-                # Autodiscovery IPv6 using SLAAC
-                # in.ndpd will be started later, we just need to plumb the interface
-                ADMIN_NIC_UP=true
-            fi
         fi
+
+        ADMIN_NIC_UP=true
 
         # don't setup resolv.conf, IPv6 addresses already work
     fi

--- a/overlay/generic/lib/svc/method/net-physical
+++ b/overlay/generic/lib/svc/method/net-physical
@@ -219,6 +219,74 @@ function vnic_up
     fi
     eval "vnic_${iface}_up=true"
 }
+function vnic_up6
+{
+    set -o xtrace
+
+    typeset link="$1"
+    typeset iface="$2"
+    typeset ip="$3"
+    typeset netmask="$4"
+    typeset vlan_id="$5"
+    typeset mac_addr="$6"
+    typeset mtu="$7"
+    typeset details="link='${link}', iface='${iface}', ip='${ip}', netmask='${netmask}, vlan_id='${vlan_id}'"
+    typeset vlan_opt=
+    typeset mac_addr_opt=
+    typeset prop_opt=
+
+    if [[ -z ${link} ]] || [[ -z ${iface} ]] || [[ -z ${ip} ]] || ([[ ${ip} != "auto" ]] && [[ -z ${netmask} ]]); then
+        echo "WARNING: not bringing up nic (insufficient configuration): $details"
+        return
+    fi
+
+    if [[ -n ${mac_addr} ]] && [[ -n ${ActiveAggrLinks[${mac_addr}]} ]]; then
+        echo "WARNING: trying to assign MAC address \"${mac_addr}\" to vnic," \
+            " but it already belongs to link aggr \"${ActiveAggrLinks[${mac_addr}]}\""
+        return
+    fi
+
+    # only bring up nic if not already up
+    eval "vnic_already_up=\${vnic_${iface}_up}"
+    if [[ -z "${vnic_already_up}" ]]; then
+        echo "Bringing up nic: $details"
+
+        if [[ -n ${vlan_id} ]] && [[ ${vlan_id} != 0 ]]; then
+            vlan_opt="-v ${vlan_id}"
+        fi
+
+        if [[ -n ${mac_addr} ]]; then
+            mac_addr_opt="-m ${mac_addr}"
+        fi
+
+        if [[ -n ${mtu} ]]; then
+            valid_mtu ${iface} ${mtu}
+            prop_opt="-p mtu=${mtu}"
+        fi
+
+        /usr/sbin/dladm create-vnic -t -l ${link} ${prop_opt} ${vlan_opt} \
+            ${mac_addr_opt} ${iface}
+        if [[ $? -ne 0 ]]; then
+            echo "Failed to create VNIC ${iface}"
+            exit $SMF_EXIT_ERR_FATAL
+        fi
+    fi
+
+    /sbin/ifconfig ${iface} inet6 plumb
+    if [[ $? -ne 0 ]]; then
+        echo "Failed to plumb ${iface}"
+        exit $SMF_EXIT_ERR_FATAL
+    fi
+
+    if [[ ${ip} == "auto" ]] || [[ -n ${ip} ]] && [[ -n ${netmask} ]]; then
+        /sbin/ifconfig ${iface} inet6 up
+    fi
+    if [[ -n ${ip} ]] && [[ -n ${netmask} ]]; then
+        /sbin/ifconfig ${iface} inet6 \
+            addif ${ip}/${netmask} preferred up
+    fi
+    eval "vnic_${iface}_up=true"
+}
 
 # If there are aggregations in sysinfo, set them up.
 function create_aggrs
@@ -496,11 +564,27 @@ if smf_is_globalzone; then
         # The installer may have set up external0, so if it already
         # exists, we're not going to try and set up the vnic again.
         #
+        do_external=
         if ! dladm show-vnic external0 > /dev/null; then
+            do_external="yes"
+        fi
+        if [[ ${do_external} == "yes" ]]; then
             vnic_up "${SYSINFO_NIC_external}" "external0" \
                 "${CONFIG_external_ip}" "${CONFIG_external_netmask}" \
                 "${CONFIG_external_vlan_id}" "${CONFIG_external_mac}" \
                 "primary" "${CONFIG_external_mtu}"
+        fi
+    fi
+    if [[ -n ${SYSINFO_NIC_external} ]] && [[ -n "${CONFIG_external_ip6}" ]]; then
+        #
+        # The installer may have set up external0, so if it already
+        # exists, we're not going to try and set up the vnic again.
+        #
+        if [[ ${do_external} == "yes" ]]; then
+            vnic_up6 "${SYSINFO_NIC_external}" "external0" \
+                "${CONFIG_external_ip6}" "${CONFIG_external_netmask6}" \
+                "${CONFIG_external_vlan_id}" "${CONFIG_external_mac}" \
+                "${CONFIG_external_mtu}"
         fi
     fi
 
@@ -513,10 +597,14 @@ if smf_is_globalzone; then
 
         if boot_file_config_enabled; then
             bootparam_ip_keys=""
+            bootparam_ip6_keys=""
             config_ip_keys=${CONFIG_bootfile_ip_keys//,/ }
+            config_ip6_keys=${CONFIG_bootfile_ip6_keys//,/ }
         else
             bootparam_ip_keys=$(sdc_bootparams_keys | grep -- "-ip$" || true)
+            bootparam_ip6_keys=$(sdc_bootparams_keys | grep -- "-ip6$" || true)
             config_ip_keys=$(sdc_config_keys | grep "_ip$" || true)
+            config_ip6_keys=$(sdc_config_keys | grep "_ip6$" || true)
         fi
 
         for tag in "${tags[@]}"; do
@@ -554,6 +642,36 @@ if smf_is_globalzone; then
                     echo vnic_up "${link}" "${iface}" "${ip}" "${netmask}" "${vlan}" "${macaddr}" "${mtu}"
                     vnic_up "${link}" "${iface}" "${ip}" "${netmask}" \
                         "${vlan}" "${macaddr}" "" "${mtu}"
+                fi
+            done
+
+            for key in ${config_ip6_keys}; do
+                if [[ ${key} == ${tag}[0-9]_ip6 ]] || [[ ${key} == ${tag}[0-9][0-9]_ip6 ]]; then
+                    iface=${key//_i6p/}
+                    #echo "   iface=$iface"
+                    eval "ip=\${CONFIG_${iface}_ip6}"
+                    eval "netmask=\${CONFIG_${iface}_netmask6}"
+                    eval "vlan=\${CONFIG_${iface}_vlan_id}"
+                    eval "macaddr=\${CONFIG_${iface}_mac}"
+                    eval "mtu=\${CONFIG_${iface}_mtu}"
+
+                    echo vnic_up6 "${link}" "${iface}" "${ip}" "${netmask}" "${vlan}" "${macaddr}" "${mtu}"
+                    vnic_up6 "${link}" "${iface}" "${ip}" "${netmask}" \
+                        "${vlan}" "${macaddr}" "${mtu}"
+                fi
+            done
+
+            for key in ${bootparam_ip6_keys}; do
+                if [[ ${key} == ${tag}[0-9]-ip6 ]] || [[ ${key} == ${tag}[0-9][0-9]-ip6 ]]; then
+                    iface=${key//-ip6/}
+                    eval "ip=\${BOOT_${iface}_ip6}"
+                    eval "netmask=\${BOOT_${iface}_netmask6}"
+                    eval "vlan=\${BOOT_${iface}_vlan_id}"
+                    eval "macaddr=\${BOOT_${iface}_mac}"
+                    eval "mtu=\${CONFIG_${iface}_mtu}"
+                    echo vnic_up6 "${link}" "${iface}" "${ip}" "${netmask}" "${vlan}" "${macaddr}" "${mtu}"
+                    vnic_up6 "${link}" "${iface}" "${ip}" "${netmask}" \
+                        "${vlan}" "${macaddr}" "${mtu}"
                 fi
             done
 

--- a/overlay/generic/lib/svc/method/net-physical
+++ b/overlay/generic/lib/svc/method/net-physical
@@ -482,7 +482,7 @@ if smf_is_globalzone; then
 
             # Configure static IPv6
             /sbin/ifconfig ${SYSINFO_NIC_admin} inet6 \
-                addif ${admin_ip6}/${admin_netmask6} up
+                addif ${admin_ip6}/${admin_netmask6} preferred up
             ADMIN_NIC_UP=true
         else
             if [[ ${admin_ip6} == "auto" ]]; then

--- a/overlay/generic/lib/svc/method/net-physical
+++ b/overlay/generic/lib/svc/method/net-physical
@@ -539,7 +539,7 @@ if smf_is_globalzone; then
         fi
     fi
 
-    if [[ -n $ip && -n $netmask ]] || [[ $ip == 'auto' ]]; then
+    if [[ -n $admin_ip6 && -n $admin_netmask6 ]] || [[ $admin_ip6 == 'auto' ]]; then
         # Plumb interface for inet6
         ifconfig ${SYSINFO_NIC_admin} inet6 plumb up
 

--- a/overlay/generic/lib/svc/method/net-physical
+++ b/overlay/generic/lib/svc/method/net-physical
@@ -278,25 +278,8 @@ function set_default_route
         default_gw=${CONFIG_external_gateway}
     fi
 
-    if [[ -n ${CONFIG_admin_gateway6} ]]; then
-        default_gw6="${CONFIG_admin_gateway6}"
-
-    elif [[ -n ${BOOT_admin_gateway6} ]]; then
-        default_gw6=${BOOT_admin_gateway6}
-
-    elif [[ -n ${CONFIG_external_gateway6} ]]; then
-        default_gw6=${CONFIG_external_gateway6}
-    fi
-
     if [[ -n ${default_gw} ]]; then
         echo "${default_gw}" > /etc/defaultrouter
-    fi
-
-    if [[ -n ${default_gw6} ]]; then
-        # flush existing autoconfigured default routes
-        /usr/sbin/route flush -inet6
-        # add static route
-        /usr/sbin/route add -inet6 default ${default_gw6}
     fi
 }
 


### PR DESCRIPTION
## Globalzone IPv6 support
This should enable IPv6 support for the admin and external NICs. Fixing #464 

Paging @wiedi for testing.
Platform image available here: http://sjorge.sinners.be/platform-20150814T174741Z.iso 

### examples
#### pure autoconfiguration
```
admin_ip6=addrconf
```
#### static (also does auto configuration as in.ndpd needs to be running)
```
admin_ip6=2001:6f8:1480:10::123
```
Overwrite the default prefix (/64)
```
admin_ip6=2001:6f8:1480:10::123/48
```

### notes
```admin_gateway6``` is also supported, however in.ndpd will overwrite the default route if one is present. 

I have found no way to prevent this. (route flush -inet6 has no effect as in.ndpd runs **after** network/physical) There is no equivalent of /etc/defaultrouter6.

This is implemented to use in a pure static environment without a router advertising prefixes.