### PR TITLE
Fix vmunbundle to allow 'vmadm receive' to have raw JSON parsed to it

### DIFF
--- a/src/vmunbundle.c
+++ b/src/vmunbundle.c
@@ -253,18 +253,22 @@ get_header(int fd, header_t *header, int fallback_to_raw)
              * handles the case where you just pipe raw JSON to vmadm receive.
              *
              */
+            size_t chunk_size = 0;
             fprintf(stderr, "No magic! Dumping raw JSON.\n");
             (void) write_bytes(1, data, data_size);
             while ((nread = read_bytes(fd, (char *)data,
                 VMBUNDLE_HEADER_SIZE)) > 0) {
 
                 fprintf(stderr, "got %d bytes\n", nread);
+                chunk_size += nread;
                 (void) write_bytes(1, data, nread);
             }
             if (nread < 0) {
                 fprintf(stderr, "Error %d reading raw data\n", nread);
                 return (-1);
             }
+            fprintf(stderr, "Name: [JSON]\n");
+            fprintf(stderr, "Size: %zu\n", chunk_size);
             return (-2);
         } else {
             fprintf(stderr, "No magic!\n");

--- a/src/vmunbundle.c
+++ b/src/vmunbundle.c
@@ -253,7 +253,7 @@ get_header(int fd, header_t *header, int fallback_to_raw)
              * handles the case where you just pipe raw JSON to vmadm receive.
              *
              */
-            size_t chunk_size = 0;
+            size_t chunk_size = data_size;
             fprintf(stderr, "No magic! Dumping raw JSON.\n");
             (void) write_bytes(1, data, data_size);
             while ((nread = read_bytes(fd, (char *)data,


### PR DESCRIPTION
According to https://github.com/joyent/smartos-live/blob/master/src/vm/README.migration, it should be possible to pipe the JSON output of vmadm get into vmadm receive (once the ZFS datasets are moved across) to re-install the zone. In practice, when attempted on joyent_20150903T073920Z (and seemingly since inception as the logic hasn't changed) vmadm receive will fail with 'Failed to get JSON!'. 

This is because the condition in VM.js receiveStdinChunk requires a chunk name and size to be provided by vmunbundle. When raw JSON is passed into vmunbundle, it fails to find the 'magic header' that vmadm send generates so it dumps the raw JSON and exits prior to printing the chunk_name and chunk_size. These two parameters don't actually get calculated as they are pulled from the header. 

This change simply provides the data expected by VM.js in the case of raw JSON being used. Looking at the comments in vmunbundle the intention seems to have been there. 