### PR TITLE
Improve IPv6 support in globalzone

### DIFF
--- a/overlay/generic/lib/svc/method/identity-node
+++ b/overlay/generic/lib/svc/method/identity-node
@@ -164,23 +164,33 @@ fi
 # Reloading sysinfo here serves two purposes:
 #   - getting the IP info (which should exist now)
 #   - updating the host info (which we just set)
+#   - ndp needs some time to stabilize to get addrconf
+[ -n "$CONFIG_admin_ip6" ] && sleep 3
 eval $(/usr/bin/sysinfo -f -p | sed -e "s/^/SYSINFO_/")
 
 # Try to add the /etc/hosts entry if we can find an IP
 if [[ -n ${SYSINFO_NIC_admin} ]]; then
-    eval "ipaddr=\${SYSINFO_Network_Interface_${SYSINFO_NIC_admin}_IPv4_Address}"
+    eval "ip4addr=\${SYSINFO_Network_Interface_${SYSINFO_NIC_admin}_IPv4_Address}"
+    eval "ip6addr=\${SYSINFO_Network_Interface_${SYSINFO_NIC_admin}_IPv6_Address}"
 fi
-if [[ -z ${ipaddr} ]]; then
-    ipaddr=$(set | grep "^SYSINFO_Network_Interface_.*_IPv4_Address" | head -n1 | cut -d'=' -f2)
+if [[ -z ${ip4addr} ]]; then
+    ip4addr=$(set | grep "^SYSINFO_Network_Interface_.*_IPv4_Address" | head -n1 | cut -d'=' -f2)
+    # empty value ends up as '' as actualy value
+    [[ "${ip4addr}" == "''" ]] && unset ip4addr
 fi
-if [[ -n ${ipaddr} ]]; then
+if [[ -z ${ip6addr} ]]; then
+    ip6addr=$(set | grep "^SYSINFO_Network_Interface_.*_IPv6_Address" | head -n1 | cut -d'=' -f2)
+    # empty value ends up as '' as actualy value
+    [[ "${ip6addr}" == "''" ]] && unset ip6addr
+fi
+if [[ -n ${ip4addr} ]] || [[ -n ${ip6addr} ]]; then
     fullname=""
 
     if [ -n "$CONFIG_dns_domain" ]; then
         fullname=" ${hostname}.${CONFIG_dns_domain}"
     fi
-
-    printf "${ipaddr}\t${hostname}${fullname}\n" >> /etc/hosts
+    [[ -n ${ip4addr} ]] && printf "${ip4addr}\t${hostname}${fullname}\n" >> /etc/hosts
+    [[ -n ${ip6addr} ]] && printf "${ip6addr}\t${hostname}${fullname}\n" >> /etc/hosts
 fi
 
 # Reset the library path now that we are past the critical stage

--- a/overlay/generic/lib/svc/method/identity-node
+++ b/overlay/generic/lib/svc/method/identity-node
@@ -175,12 +175,12 @@ if [[ -n ${SYSINFO_NIC_admin} ]]; then
 fi
 if [[ -z ${ip4addr} ]]; then
     ip4addr=$(set | grep "^SYSINFO_Network_Interface_.*_IPv4_Address" | head -n1 | cut -d'=' -f2)
-    # empty value ends up as '' as actualy value
+    # empty values end up as '' sometimes, so we clear them
     [[ "${ip4addr}" == "''" ]] && unset ip4addr
 fi
 if [[ -z ${ip6addr} ]]; then
     ip6addr=$(set | grep "^SYSINFO_Network_Interface_.*_IPv6_Address" | head -n1 | cut -d'=' -f2)
-    # empty value ends up as '' as actualy value
+    # empty values end up as '' sometimes, so we clear them
     [[ "${ip6addr}" == "''" ]] && unset ip6addr
 fi
 if [[ -n ${ip4addr} ]] || [[ -n ${ip6addr} ]]; then

--- a/overlay/generic/lib/svc/method/svc-ndp
+++ b/overlay/generic/lib/svc/method/svc-ndp
@@ -64,7 +64,7 @@ args="$args `get_daemon_option_from_property $SMF_FMRI config_file f`"
 
 # Since we potentially made network changes, update the sysinfo cache
 if smf_is_globalzone; then
-    # give in.ndp time to setup an addrconf address
+    # ndp needs some time to stabilize to get addrconf
     sleep 3
     /usr/bin/sysinfo -u
 fi

--- a/overlay/generic/lib/svc/method/svc-ndp
+++ b/overlay/generic/lib/svc/method/svc-ndp
@@ -62,9 +62,9 @@ args="$args `get_daemon_option_from_property $SMF_FMRI config_file f`"
 
 /usr/lib/inet/in.ndpd $args
 
-# Since we potentially made network changes, update the sysinfo cache
+# update the sysinfo cache, ndp potentially has made some network changes
+# - wait for ndp to stabilize, 3 seconds seems to be the sweet spot
 if smf_is_globalzone; then
-    # ndp needs some time to stabilize to get addrconf
     sleep 3
     /usr/bin/sysinfo -u
 fi

--- a/overlay/generic/lib/svc/method/svc-ndp
+++ b/overlay/generic/lib/svc/method/svc-ndp
@@ -1,0 +1,74 @@
+#!/sbin/sh
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+# ident	"%Z%%M%	%I%	%E% SMI"
+
+. /lib/svc/share/smf_include.sh
+. /lib/svc/share/routing_include.sh
+
+smf_configure_ip || exit $SMF_EXIT_OK
+
+daemon_args=`get_daemon_args $SMF_FMRI`
+options="adtf:"
+
+#
+# Handle upgrade - routing/daemon-args property must be mapped to properties
+# in routeadm property group.  Note that the SMF-incompatible -t option is not
+# supported, since it requires that in.ndpd run in the foreground.
+#
+if [ -n "$daemon_args" ]; then
+	set_daemon_boolean_property "$SMF_FMRI" "$daemon_args" \
+	    "$options" "a" stateless_addr_conf false true
+	set_daemon_boolean_property "$SMF_FMRI" "$daemon_args" \
+	    "$options" "d" debug true false
+	set_daemon_value_property "$SMF_FMRI" "$daemon_args" \
+	    "$options" "f" config_file
+	clear_daemon_args $SMF_FMRI
+fi
+
+#
+# Assemble arguments to daemon from properties
+#
+args="`get_daemon_option_from_boolean_property $SMF_FMRI stateless_addr_conf \
+	a false`"
+args="$args`get_daemon_option_from_boolean_property $SMF_FMRI debug d true`"
+if [ -n "$args" ]; then
+	args="-${args}"
+fi
+args="$args `get_daemon_option_from_property $SMF_FMRI config_file f`"
+
+
+/usr/lib/inet/in.ndpd $args
+
+# Since we potentially made network changes, update the sysinfo cache
+if smf_is_globalzone; then
+    # give in.ndp time to setup an addrconf address
+    sleep 3
+    /usr/bin/sysinfo -u
+fi
+
+[ "$?" = 0 ] || exit $SMF_EXIT_ERR_FATAL
+
+exit $SMF_EXIT_OK

--- a/overlay/generic/manifest
+++ b/overlay/generic/manifest
@@ -91,6 +91,7 @@ f lib/svc/method/manifest-import 0555 root bin
 f lib/svc/method/mdata-execute 0555 root bin
 f lib/svc/method/mdata-fetch 0555 root bin
 f lib/svc/method/net-physical 0555 root sys
+f lib/svc/method/svc-ndp 0555 root sys
 f lib/svc/method/smartdc-config 0555 root bin
 f lib/svc/method/smartdc-init 0555 root sys
 f lib/svc/method/smartdc-ur 0555 root bin

--- a/src/sysinfo
+++ b/src/sysinfo
@@ -353,6 +353,9 @@ function get_smartos_network_interfaces()
         mac=${normalized}
         ip4addr=$(ifconfig ${iface} 2>/dev/null \
             | grep "inet " | awk '{ print $2 }')
+        ip6addr=$(ifconfig ${iface}:1 inet6 2> /dev/null \
+            | grep "inet6 " | awk '{ print $2 }' \
+                            | awk -F/ '{ print $1 }')
 
         nic_tag_count=0
         while [[ ${nic_tag_count} -lt ${NicTagCount} ]]; do
@@ -372,6 +375,7 @@ function get_smartos_network_interfaces()
         NetworkInterfaces[${count}]=${iface}
         eval "Network_Interface_${iface}_MAC_Address=${mac}"
         eval "Network_Interface_${iface}_IPv4_Address=${ip4addr}"
+        eval "Network_Interface_${iface}_IPv6_Address=${ip6addr}"
         if [[ -n ${nicnames} ]]; then
             eval "Network_Interface_${iface}_NIC_Names=${nicnames}"
         fi
@@ -437,6 +441,9 @@ function get_smartos_network_interfaces()
 
         ip4addr=$(ifconfig ${iface} 2>/dev/null \
             | grep "inet " | awk '{ print $2 }')
+        ip6addr=$(ifconfig ${iface}:1 inet6 2> /dev/null \
+            | grep "inet6 " | awk '{ print $2 }' \
+                            | awk -F/ '{ print $1 }')
 
         nic_tag_count=0
         while [[ ${nic_tag_count} -lt ${NicTagCount} ]]; do
@@ -457,6 +464,7 @@ function get_smartos_network_interfaces()
         normalize_mac $(echo ${mac} | sed 's/\|/:/g')
         eval "Network_Interface_${iface}_MAC_Address=${normalized}"
         eval "Network_Interface_${iface}_IPv4_Address=${ip4addr}"
+        eval "Network_Interface_${iface}_IPv6_Address=${ip6addr}"
         if [[ -n ${nicnames} ]]; then
             eval "Network_Interface_${iface}_NIC_Names=${nicnames}"
         fi
@@ -492,9 +500,13 @@ function get_smartos_vnics()
         link_status=$(pfexec /sbin/dladm show-link -p -o state ${iface})
         ip4addr=$(ifconfig ${iface} 2>/dev/null \
             | grep "inet " | awk '{ print $2 }')
+        ip6addr=$(ifconfig ${iface}:1 inet6 2> /dev/null \
+            | grep "inet6 " | awk '{ print $2 }' \
+                            | awk -F/ '{ print $1 }')
         VirtualNetworkInterfaces[${count}]=${iface}
         eval "Virtual_Network_Interface_${iface}_MAC_Address=${mac}"
         eval "Virtual_Network_Interface_${iface}_IPv4_Address=${ip4addr}"
+        eval "Virtual_Network_Interface_${iface}_IPv6_Address=${ip6addr}"
         eval "Virtual_Network_Interface_${iface}_Link_Status=${link_status}"
         eval "Virtual_Network_Interface_${iface}_VLAN=${vlan}"
         eval "Virtual_Network_Interface_${iface}_Host_Interface=${over}"

--- a/src/sysinfo
+++ b/src/sysinfo
@@ -699,12 +699,14 @@ END
     for iface in "${NetworkInterfaces[@]}"; do
         mac_var="Network_Interface_${iface}_MAC_Address"
         ipv4_var="Network_Interface_${iface}_IPv4_Address"
+        ipv6_var="Network_Interface_${iface}_IPv6_Address"
         nicnames_var="Network_Interface_${iface}_NIC_Names"
         link_status_var="Network_Interface_${iface}_Link_Status"
         detected_tag_var="Network_Interface_${iface}_Detected_Nic_Tag"
 
         eval "mac=\${${mac_var}}"
         eval "ipv4=\${${ipv4_var}}"
+        eval "ipv6=\${${ipv6_var}}"
         eval "nicnames=\${${nicnames_var}}"
         link_status="unknown"
         eval "link_status=\${${link_status_var}}"
@@ -712,6 +714,7 @@ END
 
         echo "${mac_var}='${mac}'"
         echo "${ipv4_var}='${ipv4}'"
+        echo "${ipv6_var}='${ipv6}'"
         echo "${nicnames_var}='${nicnames}'"
         echo "${link_status_var}='${link_status}'"
         if [[ -n "${detected_tag}" ]] ; then
@@ -722,18 +725,21 @@ END
     for iface in "${VirtualNetworkInterfaces[@]}"; do
         mac_var="Virtual_Network_Interface_${iface}_MAC_Address"
         ipv4_var="Virtual_Network_Interface_${iface}_IPv4_Address"
+        ipv6_var="Virtual_Network_Interface_${iface}_IPv6_Address"
         link_status_var="Virtual_Network_Interface_${iface}_Link_Status"
         vlan_var="Virtual_Network_Interface_${iface}_VLAN"
         host_var="Virtual_Network_Interface_${iface}_Host_Interface"
 
         eval "mac=\${${mac_var}}"
         eval "ipv4=\${${ipv4_var}}"
+        eval "ipv6=\${${ipv6_var}}"
         eval "link_status=\${${link_status_var}}"
         eval "vlan=\${${vlan_var}}"
         eval "host=\${${host_var}}"
 
         echo "${mac_var}='${mac}'"
         echo "${ipv4_var}='${ipv4}'"
+        echo "${ipv6_var}='${ipv6}'"
         echo "${link_status_var}='${link_status}'"
         echo "${vlan_var}='${vlan}'"
         if [[ ${ZONENAME} == "global" ]]; then
@@ -874,6 +880,7 @@ END
     for iface in "${NetworkInterfaces[@]}"; do
         mac_var="Network_Interface_${iface}_MAC_Address"
         ipv4_var="Network_Interface_${iface}_IPv4_Address"
+        ipv6_var="Network_Interface_${iface}_IPv6_Address"
         nicnames_var="Network_Interface_${iface}_NIC_Names"
         link_status_var="Network_Interface_${iface}_Link_Status"
         detected_tag_var="Network_Interface_${iface}_Detected_Nic_Tag"
@@ -882,6 +889,7 @@ END
 
         eval "mac=\${${mac_var}}"
         eval "ipv4=\${${ipv4_var}}"
+        eval "ipv6=\${${ipv6_var}}"
         eval "nicnames=\${${nicnames_var}}"
         eval "link_status=\${${link_status_var}}"
         eval "detected_tag=\${${detected_tag_var}}"
@@ -901,6 +909,7 @@ END
         echo -n "    \"${iface}\": {"
         echo -n "\"MAC Address\": \"${mac}\", "
         echo -n "\"ip4addr\": \"${ipv4}\", "
+        echo -n "\"ip6addr\": \"${ipv6}\", "
         echo -n "\"Link Status\": \"${link_status}\", "
         echo -n "${detected_fmt}"
         echo -n "\"NIC Names\": [${nic_names_fmt}]}"
@@ -917,12 +926,14 @@ END
     for iface in "${VirtualNetworkInterfaces[@]}"; do
         mac_var="Virtual_Network_Interface_${iface}_MAC_Address"
         ipv4_var="Virtual_Network_Interface_${iface}_IPv4_Address"
+        ipv6_var="Virtual_Network_Interface_${iface}_IPv6_Address"
         link_status_var="Virtual_Network_Interface_${iface}_Link_Status"
         vlan_var="Virtual_Network_Interface_${iface}_VLAN"
         parent_var="Virtual_Network_Interface_${iface}_Host_Interface"
 
         eval "mac=\${${mac_var}}"
         eval "ipv4=\${${ipv4_var}}"
+        eval "ipv6=\${${ipv6_var}}"
         eval "link_status=\${${link_status_var}}"
         eval "vlan=\${${vlan_var}}"
         eval "host=\${${host_var}}"
@@ -934,6 +945,7 @@ END
         echo -n "    \"${iface}\": {"
         echo -n "\"MAC Address\": \"${mac}\", "
         echo -n "\"ip4addr\": \"${ipv4}\", "
+        echo -n "\"ip6addr\": \"${ipv6}\", "
         echo -n "\"Link Status\": \"${link_status}\", "
         if [[ ${ZONENAME} == "global" ]]; then
             echo -n "\"Host Interface\": \"${host}\", "


### PR DESCRIPTION
#### summary
This PR further improved IPv6 support for compute nodes/smartos.

- sysinfo now also lists IPv6 addresses
- /etc/hosts now also gets IPv6 entry if needed

#### detailed explanation of changes

1. svc-ndp got added to the overlay
We give in.ndp time to stabilize, 3 seconds seems to be the sweet spot. (At least in my testing).
After that we update the sysinfo cache, when using addrconf or static IPv6 ndp will make some changes to the network. Like binding the allocated IPv6 address and updating the routes.

I chose not to pull in the sdc config into svc-ndp and just do the small 3 second delay regardless if we have admin_ip6 set or not. Although I am willing to change this if this is preferred to skip it or not.

Boot delay seemed to be none existing, probably due to smf starting some services in parallel.

2. sysinfo
ipaddr variable is renamed to ip4addr and ip6addr has been added. Additional properties for ipv6 addresses have been added. IPv6 info can now be queried like IPv4 info, this will be used later.

3. identity-node
With the updated sysinfo we can now obtain the IPv6 address and also add host entries to /etc/hosts. This should allow sendmail to again resolve all it's own addresses.

The 3 second wait for sysinfo to stabilize here is optional as the CONFIG_ is available, we skip this when admin_ip6 is not set.

#### test data
1. no IPv6
/usbkey/config
```
#
# This file was auto-generated and must be source-able by bash.
#

# admin_nic is the nic admin_ip will be connected to for headnode zones.
admin_nic=0:15:0:5:d9:c1
admin_ip=dhcp
admin_netmask=
admin_network=
admin_gateway=dhcp

#admin_ip6=addrconf
#admin_ip6=2001:zzzz:yyy:xxxx::234/48

#external_nic=12:b0:5b:e:28:4e
#external_ip=127.0.1.1
#external_netmask=255.255.255.0
#external_ip6=addrconf

headnode_default_gateway=

dns_resolvers=8.8.8.8,8.8.4.4
hostname=soth
dns_domain=acheron.be

ntp_hosts=ntp.acheron.be
compute_node_ntp_hosts=dhcp
```

/etc/hosts
```
# CDDL HEADER START
#
# The contents of this file are subject to the terms of the
# Common Development and Distribution License (the "License").
# You may not use this file except in compliance with the License.
#
# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
# or http://www.opensolaris.org/os/licensing.
# See the License for the specific language governing permissions
# and limitations under the License.
#
# When distributing Covered Code, include this CDDL HEADER in each
# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
# If applicable, add the following below this CDDL HEADER, with the
# fields enclosed by brackets "[]" replaced with your own identifying
# information: Portions Copyright [yyyy] [name of copyright owner]
#
# CDDL HEADER END
#
# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
# Use is subject to license terms.
#
# Internet host table
#
::1             localhost
127.0.0.1       localhost loghost
172.16.xx.227   soth soth.acheron.be
```

output of sysinfo
```
Live_Image='20151031T170124Z'
System_Type='SunOS'
Boot_Time='1446332086'
SDC_Version='7.0'
Manufacturer='Joyent'
Product='SmartDC HVM'
Serial_Number='618a01b8-c37b-473f-8cdb-ca2a66d6adf7'
SKU_Number='001'
HW_Version='7.20151029T053122Z'
HW_Family='Virtual Machine'
VM_Capable='true'
CPU_Type='Unknown'
CPU_Virtualization='none'
CPU_Physical_Cores=0
Nic_Tags=external,admin
Setup='false'
UUID='618a01b8-c37b-473f-8cdb-ca2a66d6adf7'
Hostname='soth'
CPU_Total_Cores=2
MiB_of_Memory=2047
Disk_c0d1_size_in_GB=21
NIC_external='vioif1'
NIC_admin='vioif0'
Network_Interface_vioif0_MAC_Address='00:15:00:05:d9:c1'
Network_Interface_vioif0_IPv4_Address='172.16.xx.227'
Network_Interface_vioif0_IPv6_Address=''
Network_Interface_vioif0_NIC_Names='admin'
Network_Interface_vioif0_Link_Status='up'
Network_Interface_vioif1_MAC_Address='12:b0:5b:0e:28:4e'
Network_Interface_vioif1_IPv4_Address=''
Network_Interface_vioif1_IPv6_Address=''
Network_Interface_vioif1_NIC_Names='external'
Network_Interface_vioif1_Link_Status='up'
Virtual_Network_Interface_external0_MAC_Address='02:08:20:1c:5a:24'
Virtual_Network_Interface_external0_IPv4_Address=''
Virtual_Network_Interface_external0_IPv6_Address=''
Virtual_Network_Interface_external0_Link_Status='up'
Virtual_Network_Interface_external0_VLAN='0'
Virtual_Network_Interface_external0_Host_Interface='vioif1'
Bootparam_console='vga'
Bootparam_vga_mode='115200,8,n,1,-'
Bootparam_root_shadow='$5$2HOHRnK3$NvLlm.1KQBbB0WjoP7xcIwGnllhzp2HnT.mDO7DpxYA'
Bootparam_smartos='true'
```
2. addrconf
/usbkey/config
```
#
# This file was auto-generated and must be source-able by bash.
#

# admin_nic is the nic admin_ip will be connected to for headnode zones.
admin_nic=0:15:0:5:d9:c1
admin_ip=dhcp
admin_netmask=
admin_network=
admin_gateway=dhcp

admin_ip6=addrconf
#admin_ip6=2001:zzzz:yyy:xxxx::234/48


#external_nic=12:b0:5b:e:28:4e
#external_ip=127.0.1.1
#external_netmask=255.255.255.0
#external_ip6=addrconf

headnode_default_gateway=

dns_resolvers=8.8.8.8,8.8.4.4
hostname=soth
dns_domain=acheron.be

ntp_hosts=ntp.acheron.be
compute_node_ntp_hosts=dhcp
```

/etc/hosts
```
# CDDL HEADER START
#
# The contents of this file are subject to the terms of the
# Common Development and Distribution License (the "License").
# You may not use this file except in compliance with the License.
#
# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
# or http://www.opensolaris.org/os/licensing.
# See the License for the specific language governing permissions
# and limitations under the License.
#
# When distributing Covered Code, include this CDDL HEADER in each
# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
# If applicable, add the following below this CDDL HEADER, with the
# fields enclosed by brackets "[]" replaced with your own identifying
# information: Portions Copyright [yyyy] [name of copyright owner]
#
# CDDL HEADER END
#
# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
# Use is subject to license terms.
#
# Internet host table
#
::1             localhost
127.0.0.1       localhost loghost
172.16.xx.227   soth soth.acheron.be
2001:zzzz:yyy:xxxx:215:ff:fe05:d9c1       soth soth.acheron.be
```

output of sysinfo
```
Live_Image='20151031T170124Z'
System_Type='SunOS'
Boot_Time='1446332236'
SDC_Version='7.0'
Manufacturer='Joyent'
Product='SmartDC HVM'
Serial_Number='618a01b8-c37b-473f-8cdb-ca2a66d6adf7'
SKU_Number='001'
HW_Version='7.20151029T053122Z'
HW_Family='Virtual Machine'
VM_Capable='true'
CPU_Type='Unknown'
CPU_Virtualization='none'
CPU_Physical_Cores=0
Nic_Tags=external,admin
Setup='false'
UUID='618a01b8-c37b-473f-8cdb-ca2a66d6adf7'
Hostname='soth'
CPU_Total_Cores=2
MiB_of_Memory=2047
Disk_c0d1_size_in_GB=21
NIC_external='vioif1'
NIC_admin='vioif0'
Network_Interface_vioif0_MAC_Address='00:15:00:05:d9:c1'
Network_Interface_vioif0_IPv4_Address='172.16.xx.227'
Network_Interface_vioif0_IPv6_Address='2001:zzzz:yyy:xxxx:215:ff:fe05:d9c1'
Network_Interface_vioif0_NIC_Names='admin'
Network_Interface_vioif0_Link_Status='up'
Network_Interface_vioif1_MAC_Address='12:b0:5b:0e:28:4e'
Network_Interface_vioif1_IPv4_Address=''
Network_Interface_vioif1_IPv6_Address=''
Network_Interface_vioif1_NIC_Names='external'
Network_Interface_vioif1_Link_Status='up'
Virtual_Network_Interface_external0_MAC_Address='02:08:20:51:9f:72'
Virtual_Network_Interface_external0_IPv4_Address=''
Virtual_Network_Interface_external0_IPv6_Address=''
Virtual_Network_Interface_external0_Link_Status='up'
Virtual_Network_Interface_external0_VLAN='0'
Virtual_Network_Interface_external0_Host_Interface='vioif1'
Bootparam_console='vga'
Bootparam_vga_mode='115200,8,n,1,-'
Bootparam_root_shadow='$5$2HOHRnK3$NvLlm.1KQBbB0WjoP7xcIwGnllhzp2HnT.mDO7DpxYA'
Bootparam_smartos='true'
```

3. static
/usbkey/config
```
#
# This file was auto-generated and must be source-able by bash.
#

# admin_nic is the nic admin_ip will be connected to for headnode zones.
admin_nic=0:15:0:5:d9:c1
admin_ip=dhcp
admin_netmask=
admin_network=
admin_gateway=dhcp

#admin_ip6=addrconf
admin_ip6=2001:zzzz:yyy:xxxx::234/48

#external_nic=12:b0:5b:e:28:4e
#external_ip=127.0.1.1
#external_netmask=255.255.255.0
#external_ip6=addrconf

headnode_default_gateway=

dns_resolvers=8.8.8.8,8.8.4.4
hostname=soth
dns_domain=acheron.be

ntp_hosts=ntp.acheron.be
compute_node_ntp_hosts=dhcp
```

/etc/hosts
```
# CDDL HEADER START
#
# The contents of this file are subject to the terms of the
# Common Development and Distribution License (the "License").
# You may not use this file except in compliance with the License.
#
# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
# or http://www.opensolaris.org/os/licensing.
# See the License for the specific language governing permissions
# and limitations under the License.
#
# When distributing Covered Code, include this CDDL HEADER in each
# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
# If applicable, add the following below this CDDL HEADER, with the
# fields enclosed by brackets "[]" replaced with your own identifying
# information: Portions Copyright [yyyy] [name of copyright owner]
#
# CDDL HEADER END
#
# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
# Use is subject to license terms.
#
# Internet host table
#
::1             localhost
127.0.0.1       localhost loghost
172.16.10.227   soth soth.acheron.be
2001:zzzz:yyy:xxxx::234   soth soth.acheron.be
```

output of sysinfo
```
Live_Image='20151031T170124Z'
System_Type='SunOS'
Boot_Time='1446332403'
SDC_Version='7.0'
Manufacturer='Joyent'
Product='SmartDC HVM'
Serial_Number='618a01b8-c37b-473f-8cdb-ca2a66d6adf7'
SKU_Number='001'
HW_Version='7.20151029T053122Z'
HW_Family='Virtual Machine'
VM_Capable='true'
CPU_Type='Unknown'
CPU_Virtualization='none'
CPU_Physical_Cores=0
Nic_Tags=admin
Setup='false'
UUID='618a01b8-c37b-473f-8cdb-ca2a66d6adf7'
Hostname='soth'
CPU_Total_Cores=2
MiB_of_Memory=2047
Disk_c0d1_size_in_GB=21
NIC_admin='vioif0'
Network_Interface_vioif0_MAC_Address='00:15:00:05:d9:c1'
Network_Interface_vioif0_IPv4_Address='172.16.xx.227'
Network_Interface_vioif0_IPv6_Address='2001:zzzz:yyy:xxxx::234'
Network_Interface_vioif0_NIC_Names='admin'
Network_Interface_vioif0_Link_Status='up'
Network_Interface_vioif1_MAC_Address='12:b0:5b:0e:28:4e'
Network_Interface_vioif1_IPv4_Address=''
Network_Interface_vioif1_IPv6_Address=''
Network_Interface_vioif1_NIC_Names=''
Network_Interface_vioif1_Link_Status='up'
Bootparam_console='vga'
Bootparam_vga_mode='115200,8,n,1,-'
Bootparam_root_shadow='$5$2HOHRnK3$NvLlm.1KQBbB0WjoP7xcIwGnllhzp2HnT.mDO7DpxYA'
Bootparam_smartos='true'
```

#### test image
http://sjorge.sinners.be/illumos/joyent/platform-20151031T170124Z.iso

@melloc I guess I need to poke you for this
