### PR TITLE
kernel cifs server now works in joyent branded zones

### DIFF
--- a/overlay/generic/usr/lib/brand/joyent-minimal/config.xml
+++ b/overlay/generic/usr/lib/brand/joyent-minimal/config.xml
@@ -90,6 +90,7 @@
 	<privilege set="default" name="sys_iptun_config" ip-type="exclusive" />
 	<privilege set="default" name="sys_mount" />
 	<privilege set="default" name="sys_nfs" />
+	<privilege set="default" name="sys_smb" />
 	<privilege set="default" name="sys_resource" />
 	<privilege set="default" name="sys_ppp_config" ip-type="exclusive" />
 

--- a/overlay/generic/usr/lib/brand/joyent-minimal/platform.xml
+++ b/overlay/generic/usr/lib/brand/joyent-minimal/platform.xml
@@ -90,6 +90,7 @@
 	<device match="rlofi" />
 	<device match="rmt" />
 	<device match="sad/user" />
+	<device match="smbsrv" />
 	<device match="signalfd" />
 	<device match="svvslo0" />
 	<device match="svvslo1" />

--- a/overlay/generic/usr/lib/brand/joyent/config.xml
+++ b/overlay/generic/usr/lib/brand/joyent/config.xml
@@ -90,6 +90,7 @@
 	<privilege set="default" name="sys_iptun_config" ip-type="exclusive" />
 	<privilege set="default" name="sys_mount" />
 	<privilege set="default" name="sys_nfs" />
+	<privilege set="default" name="sys_smb" />
 	<privilege set="default" name="sys_resource" />
 	<privilege set="default" name="sys_ppp_config" ip-type="exclusive" />
 

--- a/overlay/generic/usr/lib/brand/joyent/manifests
+++ b/overlay/generic/usr/lib/brand/joyent/manifests
@@ -33,7 +33,6 @@
 # network/socket-filter-kssl.xml
 # network/ssl/kssl-proxy.xml
 # network/nfs/rquota.xml
-# network/smb/server.xml
 # network/dns/server.xml
 # network/ftp.xml
 # network/finger.xml
@@ -130,6 +129,7 @@ network/routing/ripng.xml	disabled
 network/routing/route.xml	disabled
 network/rpc/bind.xml		enabled
 network/smb/client.xml		disabled
+network/smb/server.xml          disabled
 network/shares/group.xml	enabled
 network/shares/reparsed.xml	disabled
 network/shell.xml		disabled

--- a/overlay/generic/usr/lib/brand/joyent/platform.xml
+++ b/overlay/generic/usr/lib/brand/joyent/platform.xml
@@ -91,6 +91,7 @@
 	<device match="rlofi" />
 	<device match="rmt" />
 	<device match="sad/user" />
+	<device match="smbsrv" />
 	<device match="signalfd" />
 	<device match="svvslo0" />
 	<device match="svvslo1" />

--- a/overlay/generic/usr/lib/brand/lx/config.xml
+++ b/overlay/generic/usr/lib/brand/lx/config.xml
@@ -86,6 +86,7 @@
 	<privilege set="default" name="sys_iptun_config" ip-type="exclusive" />
 	<privilege set="default" name="sys_mount" />
 	<privilege set="default" name="sys_nfs" />
+	<privilege set="default" name="sys_smb" />
 	<privilege set="default" name="sys_resource" />
 	<privilege set="default" name="sys_ppp_config" ip-type="exclusive" />
 


### PR DESCRIPTION
http://sjorge.sinners.be/illumos/joyent/platform-20151117T110648Z.iso
http://sjorge.sinners.be/illumos/joyent/platform-20151117T110648Z.tgz

Just creaste a new zone that has the ```limit_priv``` set to ```default,sys_smb```
```json
{
  "brand": "joyent",
  "limit_priv": "default,sys_smb",
  "max_physical_memory": 256,
  "quota": 5,
  "nics": [
    ...
  ]
}
```

You should be able to enabe smb/server on a joyent branded zone (not imported by default on minimal).

```bash
svcadm enable smb/server
svcadm enable smb/client
svcadm enable bind
svcadm enable idmap
```

```
online         13:42:36 svc:/network/rpc/bind:default
online         13:42:43 svc:/system/idmap:default
online         13:42:43 svc:/network/smb/client:default
online         13:42:44 svc:/network/smb/server:default
online         13:42:45 svc:/network/shares/group:zfs
online         13:42:45 svc:/network/shares/group:smb
```