### PR TITLE
Updated smartos_prompt_config.sh to address issues/519

### DIFF
--- a/overlay/generic/smartdc/lib/smartos_prompt_config.sh
+++ b/overlay/generic/smartdc/lib/smartos_prompt_config.sh
@@ -854,13 +854,10 @@ setup_datasets()
 		# issue for locked anonymous memory that is backed by
 		# in-memory swap (which will severely and artificially limit
 		# VM tenancy).  We will therfore not create a swap device
-		# smaller than DRAM -- but we still allow for the
-		# configuration variable to account for actual consumed space
-		# by using it to set the refreservation on the swap volume
-		# if/when the specified size is smaller than DRAM.
+		# smaller than DRAM
 		#
 
-		size=${SYSINFO_MiB_of_Memory}
+		size=$(LC_ALL=C LANG=C sysinfo -p |awk -F = '/MiB_of_Memory=/ {print $NF}')
 		zfs create -V ${size}mb ${SWAPVOL} || fatal \
 		    "failed to create swap partition"
 


### PR DESCRIPTION
This is a minor change, we remove the use of SYSINFO_MiB_of_Memory and change
to use a direct function to get the ram size. In some edge cases the  SYSINFO_MiB_of_Memory is empty and results in a failed install. 
