### PR TITLE
FIX: enable multicast DNS lookup in global zone

### DIFF
--- a/overlay/generic/etc/nsswitch.conf
+++ b/overlay/generic/etc/nsswitch.conf
@@ -29,8 +29,8 @@
 
 passwd:     files
 group:      files
-hosts:      files dns mdns
-ipnodes:    files dns mdns
+hosts:      files mdns dns
+ipnodes:    files mdns dns
 networks:   files
 protocols:  files
 rpc:        files


### PR DESCRIPTION
Background: Many US ISPs nameservers do not return NXDOMAIN but instead the IP of a search page to generate ad revenue. This can break lookup of multicast DNS hosts (hostname.local) if the nameserver is queried before the mDNS service. In SmartOS non-global zones, the search order is files (/etc/hosts), mDNS, DNS. In the global zone, the order is (files, dns, mdns).

Fix: I inverted the order of dns and mdns in /etc/nsswitch.com. This fixes multicast DNS lookups in the global zone for those of us with broken nameservers.
