### PR TITLE
The packages not from pkgsrc are not signed

### DIFF
--- a/configure
+++ b/configure
@@ -109,7 +109,8 @@ function install_pkgin
 			curl -k "$conf_pkgsrcurl/$pkg.tgz" -o \
 			    /var/tmp/$pkg.tgz || fatal \
 			    "failed to fetch $pkg.tgz"
-			$conf_priv pkg_add /var/tmp/$pkg.tgz || fatal \
+			# The "-C /dev/null" is because these packages are not signed
+			$conf_priv pkg_add -C /dev/null /var/tmp/$pkg.tgz || fatal \
 			    "failed to pkg_add $pkg"
 			rm -f /var/tmp/$pkg.tgz
 		fi


### PR DESCRIPTION
The build instructions wiki page (https://wiki.smartos.org/display/DOC/Building+SmartOS+on+SmartOS) directs people to use base-multiarch-lts 14.4.X.
The pkgsrc trees in from 2014Q4 and later use signed packages and the pkgsrc configuration is set to verify signatures.

Unfortunately part of the configure step for building SmartOS pulls down some unsigned packages that are needed to set up the build environment.

This causes the configure step to be interactive rather than fully automatic.

People were getting confused on IRC and @jperkin suggested a simple workaround that is included in this pull request.

I believe this is important because I'm pretty sure that mountain-gorilla expects the configure step to run to completion on its own rather than be interactive.

As my additional comment below indicates, I updated the wiki page so that people will stop being surprised, but I think that we should fix this.
