### PR TITLE
joyent/smartos#541 USB image partition table is not 4k aligned

### DIFF
--- a/tools/usb_fdisk_table
+++ b/tools/usb_fdisk_table
@@ -46,7 +46,7 @@
 *
 
 * Id    Act  Bhead  Bsect  Bcyl    Ehead  Esect  Ecyl    Rsect      Numsect
-  12    128  9      34     0       34     63     243     600        3905400   
+  12    128  0      0      0       0      0      0       256        3891200
   0     0    0      0      0       0      0      0       0          0         
   0     0    0      0      0       0      0      0       0          0         
   0     0    0      0      0       0      0      0       0          0         


### PR DESCRIPTION
Tests confirm that this both still boots and in some cases improves performance.