### PR TITLE
OS-4740 Docker containers up more than 10 seconds should have their d…

### DIFF
--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -20,7 +20,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2015, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2016, Joyent, Inc. All rights reserved.
  *
  * Experimental functions, expect these interfaces to be unstable and
  * potentially go away entirely:
@@ -11395,14 +11395,14 @@ function getHostvolumeFile(url, target, log, callback) {
     });
 }
 
-function setDockerRestartCount(uuid, filename, options, log, callback)
+function setDockerRestartOpts(uuid, filename, options, log, callback)
 {
     var lockpath = '/var/run/vm.' + uuid + '.config.lockfile';
     var tracers_obj;
     var unlock;
 
     if (process.env.EXPERIMENTAL_VMJS_TRACING) {
-        tracers_obj = traceUntilCallback('set-docker-restartcount', log,
+        tracers_obj = traceUntilCallback('set-docker-restartopts', log,
             callback);
         callback = tracers_obj.callback;
         log = tracers_obj.log;
@@ -11460,9 +11460,13 @@ function setDockerRestartCount(uuid, filename, options, log, callback)
                     mdata.internal_metadata['docker:restartcount'] = 1;
                 }
             } else {
-                msg = 'invalid options for setDockerRestartCount()';
+                msg = 'invalid options for setDockerRestartOpts()';
                 log.error({options: options}, msg);
                 _failed(new Error(msg));
+            }
+
+            if (options.hasOwnProperty('delay') && options.delay) {
+                mdata.internal_metadata['docker:restartdelay'] = options.delay;
             }
 
             tmp_filename = filename + '.tmp.' + process.pid;
@@ -11659,19 +11663,27 @@ exports.start = function (uuid, extra, options, callback)
                 return;
             }
         }, function (cb) {
+            var mdata_path;
+
             if (!vmobj.docker || !vmobj.zonepath) {
                 cb();
                 return;
             }
 
+            mdata_path = path.join(vmobj.zonepath, '/config/metadata.json');
+
             // we're about to restart now, so bump the restart counter if we're
             // restarting from vmadmd, otherwise just set it to 0.
             if (options.increment_restart_count) {
-                setDockerRestartCount(vmobj.uuid, vmobj.zonepath
-                    + '/config/metadata.json', {increment: 1}, log, cb);
+                setDockerRestartOpts(vmobj.uuid, mdata_path, {
+                    delay: options.restart_delay,
+                    increment: 1
+                }, log, cb);
             } else {
-                setDockerRestartCount(vmobj.uuid, vmobj.zonepath
-                    + '/config/metadata.json', {value: 0}, log, cb);
+                setDockerRestartOpts(vmobj.uuid, mdata_path, {
+                    delay: options.restart_delay,
+                    value: 0
+                }, log, cb);
             }
         }, function (cb) {
             var err;

--- a/src/vm/sbin/vmadmd.js
+++ b/src/vm/sbin/vmadmd.js
@@ -648,7 +648,7 @@ function restartDockerContainer(uuid, opts)
 {
     var restart_delay;
 
-    assert(typeof(opts) === 'object', 'opts must be object');
+    assert(typeof (opts) === 'object', 'opts must be object');
 
     restart_delay = opts.delay;
 

--- a/src/vm/sbin/vmadmd.js
+++ b/src/vm/sbin/vmadmd.js
@@ -21,7 +21,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2015, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2016, Joyent, Inc. All rights reserved.
  *
  */
 
@@ -45,7 +45,9 @@ var qs = require('querystring');
 var SyseventStream = require('/usr/vm/node_modules/sysevent-stream');
 var url = require('url');
 var util = require('util');
+var vasync = require('vasync');
 
+var DOCKER_RUNTIME_DELAY_RESET = 10000; // ms zone being up, we zero delay
 var UPGRADE_SCRIPT = '/smartdc/vm-upgrade/001_upgrade';
 var VMADMD_PORT = 8080;
 var VMADMD_AUTOBOOT_FILE = '/tmp/.autoboot_vmadmd';
@@ -113,6 +115,66 @@ function zonecfg(args, callback)
         } else {
             callback(null, {'stdout': stdout, 'stderr': stderr});
         }
+    });
+}
+
+/*
+ * This function gets the runtime of the last run of a stopped zone by comparing
+ * the mtime of the /lastbooted and /lastexited files.
+ *
+ * If there are no errors, the last_runtime property will be added to the vmobj.
+ *
+ */
+function addLastRuntime(vmobj, opts, callback)
+{
+    var lastbooted_filename;
+    var lastbooted_mtime;
+    var lastexited_filename;
+    var lastexited_mtime;
+    var zonepath = vmobj.zonepath;
+
+    assert(log, 'missing log'); // log is GLOBAL!
+    assert(zonepath, 'missing zonepath');
+
+    lastbooted_filename = path.join(vmobj.zonepath, '/lastbooted');
+    lastexited_filename = path.join(vmobj.zonepath, '/lastexited');
+
+    vasync.pipeline({funcs: [
+        function (_, cb) {
+            fs.stat(lastbooted_filename, function (err, st) {
+                if (err) {
+                    log.error({err: err, vm_uuid: vmobj.uuid},
+                        'failed to stat lastbooted');
+                    cb(err);
+                    return;
+                }
+                lastbooted_mtime = st.mtime.getTime();
+                cb();
+            });
+        }, function (_, cb) {
+            fs.stat(lastexited_filename, function (err, st) {
+                if (err) {
+                    log.error({err: err, vm_uuid: vmobj.uuid},
+                        'failed to stat lastexited');
+                    cb(err);
+                    return;
+                }
+                lastexited_mtime = st.mtime.getTime();
+                cb();
+            });
+        }
+    ]}, function (err) {
+        if (!err) {
+            assert((lastexited_mtime - lastbooted_mtime) > 0,
+                'mtime delta must be positive [' + lastexited_mtime + ' <= '
+                + lastbooted_mtime + ']');
+
+            vmobj.last_runtime = (lastexited_mtime - lastbooted_mtime);
+            log.debug({vm_uuid: vmobj.uuid, last_runtime: vmobj.last_runtime},
+                'added last_runtime to VM Object');
+        }
+
+        callback();
     });
 }
 
@@ -552,8 +614,10 @@ function rotateKVMLog(vm_uuid)
     }, 30 * 1000);
 }
 
-function restartDockerContainer(uuid, restart_count)
+function restartDockerContainer(uuid, opts)
 {
+    var restart_delay = opts.delay;
+
     VM.load(uuid, {fields: [
         'autoboot',
         'brand',
@@ -586,8 +650,10 @@ function restartDockerContainer(uuid, restart_count)
             return;
         }
 
-        VM.start(vmobj.uuid, {}, {increment_restart_count: true},
-            function (start_err) {
+        VM.start(vmobj.uuid, {}, {
+            increment_restart_count: true,
+            restart_delay: restart_delay
+        }, function (start_err) {
 
             if (start_err) {
                 log.error({err: start_err, uuid: vmobj.uuid},
@@ -651,6 +717,17 @@ function applyDockerRestartPolicy(vmobj)
         restart_count = 0;
     }
 
+    if (vmobj.last_runtime && vmobj.last_runtime > DOCKER_RUNTIME_DELAY_RESET) {
+        // If the container previously ran more than DOCKER_RUNTIME_DELAY_RESET
+        // milliseconds, we reset the delay back to initial value (as though
+        // restart_count were 0).
+        restart_delay = 100;
+    } else if (im['docker:restartdelay']) {
+        restart_delay = im['docker:restartdelay'];
+    } else {
+        restart_delay = 100 * Math.pow(2, restart_count);
+    }
+
     restart_policy = im['docker:restartpolicy'];
     parts = restart_policy.split(':');
     if (parts.length === 2 && parts[0] === 'on-failure'
@@ -687,14 +764,15 @@ function applyDockerRestartPolicy(vmobj)
         return;
     }
 
-    restart_delay = 100 * Math.pow(2, restart_count);
     log.info({uuid: vmobj.uuid}, 'delaying %s ms before (re)start',
         restart_delay);
 
     restart_waiters[vmobj.uuid] = setTimeout(function _delayedRestart() {
         // clear so someone else can run
         delete restart_waiters[vmobj.uuid];
-        restartDockerContainer(vmobj.uuid, restart_count, log);
+        restartDockerContainer(vmobj.uuid, {
+            delay: (restart_delay * 2) // increment for next time
+        });
     }, restart_delay);
 }
 
@@ -775,7 +853,8 @@ function updateZoneStatus(ev)
             'internal_metadata',
             'state',
             'uuid',
-            'zone_state'
+            'zone_state',
+            'zonepath'
         ]}, function (err, vmobj) {
             log.info(ev.zonename + ' (docker) went from ' + ev.oldstate + ' to '
                 + ev.newstate + ' at ' + ev.when);
@@ -790,8 +869,12 @@ function updateZoneStatus(ev)
                 && vmobj.internal_metadata
                 && vmobj.internal_metadata['docker:restartpolicy']) {
 
-                // no callback, nobody cares
-                applyDockerRestartPolicy(vmobj, log);
+                // Add the last_runtime field in case we should reset the delay
+                addLastRuntime(vmobj, {log: log}, function () {
+                    // no callback to call when updateZoneStatus() completes,
+                    // nobody cares about errors.
+                    applyDockerRestartPolicy(vmobj);
+                });
             }
         });
 
@@ -2268,8 +2351,10 @@ function main()
                                 'docker VM not running at vmadmd startup, '
                                 + 'applying restart policy');
 
-                            applyDockerRestartPolicy(vmobj, log);
-                            upg_cb();
+                            addLastRuntime(vmobj, {log: log}, function () {
+                                applyDockerRestartPolicy(vmobj);
+                                upg_cb();
+                            });
                         } else {
                             log.debug('ignoring non-kvm VM ' + vmobj.uuid);
                             upg_cb();

--- a/src/vm/tests/test-docker.js
+++ b/src/vm/tests/test-docker.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Joyent, Inc.  All rights reserved.
+// Copyright 2016 Joyent, Inc.  All rights reserved.
 //
 // These tests ensure that docker flag works as expected when setting/unsetting
 // Also test that /etc/resolv.conf, /etc/hosts and /etc/hostname are set
@@ -6,10 +6,12 @@
 //
 
 var async = require('/usr/node/node_modules/async');
+var EventEmitter = require('events').EventEmitter;
 var exec = require('child_process').exec;
 var fs = require('fs');
 var libuuid = require('/usr/node/node_modules/uuid');
 var path = require('path');
+var SyseventStream = require('/usr/vm/node_modules/sysevent-stream');
 var VM = require('/usr/vm/node_modules/VM');
 var vmtest = require('../common/vmtest.js');
 
@@ -1120,4 +1122,195 @@ test('test docker VM with good zlog_max_size', function (t) {
             cb(err);
         });
     }]);
+});
+
+/*
+ * Tries to determine if the array of (Number) values is generally going up or
+ * down. Returns -1 if more downs than ups, 1 if more ups than downs and 0 if
+ * there are the same number of ups and downs or the values are all equal.
+ */
+function trend(values)
+{
+    var downs = 0;
+    var prev_value = values[0];
+    var ups = 0;
+
+    values.forEach(function (val) {
+        if (val > prev_value) {
+            ups++;
+        } else if (val < prev_value) {
+            downs++;
+        }
+        prev_value = val;
+    });
+
+    if (ups === downs) {
+        return (0);
+    } else if (ups > downs) {
+        return (1);
+    } else {
+        return (-1);
+    }
+}
+
+/*
+ * This tests that OS-4740 is still fixed. Specifically if a docker container
+ * has trouble restarting the delay should be increasing, but if it stays up for
+ * at least 10 seconds the delay should get reset.
+ *
+ * This relies on vmadmd being running (since that's what handles restarts)
+ */
+test('test restart delay reset', function (t) {
+    var cycles_fail = 7;
+    var cycle_reset_delay = 15; // seconds, should be >= 10
+    var emitter = new EventEmitter();
+    var events = [];
+    var payload = JSON.parse(JSON.stringify(common_payload));
+    var se;
+    var state = {brand: payload.brand};
+    var num_cycles = (cycles_fail * 2) + 1;
+
+    payload.autoboot = false;
+    payload.archive_on_delete = true;
+    payload.brand = 'lx';
+    payload.docker = true;
+    payload.image_uuid = vmtest.CURRENT_DOCKER_ALPINE_UUID;
+    // This cmd will 'exit 1' cycles_fail times, then sleep cycle_reset_delay
+    // seconds and exit 0, then repeat that pattern.
+    payload.internal_metadata = {
+        'docker:cmd': '[\"/bin/sh\",\"-c\",'
+            + '\"[[ $(ls -1 /var/tmp | wc -l) == ' + cycles_fail + ' ]] '
+            + '&& (sleep ' + cycle_reset_delay + '; rm -f /var/tmp/*; exit 0) '
+            + '|| (touch /var/tmp/$(/native/usr/bin/uuid); exit 1)\"]',
+        'docker:restartpolicy': 'always'
+    };
+    payload.kernel_version = '3.13.0';
+
+    vmtest.on_new_vm(t, payload.image_uuid, payload, state, [
+        function (cb) {
+            var starts = 0;
+            var stops = 0;
+
+            se = new SyseventStream({
+                class: 'status',
+                channel: 'com.sun:zones:status'
+            });
+            se.on('readable', function () {
+                var ev;
+                var im;
+
+                while ((ev = se.read()) !== null) {
+                    if (ev.data.zonename === state.uuid) {
+                        if (ev.data.newstate === 'uninitialized') {
+                            im = JSON.parse(fs.readFileSync('/zones/'
+                                + ev.data.zonename + '/config/metadata.json'))
+                                .internal_metadata;
+                            stops++;
+                            events.push({
+                                action: 'stop',
+                                time: ev.data.when,
+                                restartcount: im['docker:restartcount'],
+                                restartdelay: im['docker:restartdelay']
+                            });
+                        } else if (ev.data.newstate === 'running') {
+                            starts++;
+                            events.push({
+                                action: 'start',
+                                time: ev.data.when
+                            });
+                        }
+                    }
+                }
+
+                if (starts >= num_cycles && stops >= num_cycles) {
+                    // stop the zoneevent watcher
+                    se.stop();
+                    se = null;
+                    emitter.emit('done');
+                }
+            });
+            cb();
+        }, function (cb) {
+            // start the VM
+            VM.start(state.uuid, {}, function (err) {
+                t.ok(!err, 'starting VM: ' + (err ? err.message : 'success'));
+                cb(err);
+            });
+        }, function (cb) {
+            // wait for our num_cycles to finish
+            emitter.once('done', function () {
+                var deltas = [];
+                var expected_counts = [];
+                var expected_delays = [];
+                var i;
+                var last_stop = 0;
+                var restartcounts = [];
+                var restartdelays = [];
+
+                events.forEach(function (evt) {
+                    if (evt.action === 'start') {
+                        if (last_stop > 0) {
+                            deltas.push((evt.time - last_stop) / 1000000);
+                        }
+                    } else if (evt.action === 'stop') {
+                        last_stop = evt.time;
+                    } else {
+                        throw (new Error('Unexpected action: ' + evt.action));
+                    }
+                });
+
+                restartcounts = events.filter(function (evt) {
+                    if (evt.action === 'stop') {
+                        return (true);
+                    }
+                    return (false);
+                }).map(function (evt) {
+                    return (evt.restartcount);
+                });
+
+                restartdelays = events.filter(function (evt) {
+                    if (evt.action === 'stop') {
+                        return (true);
+                    }
+                    return (false);
+                }).map(function (evt) {
+                    return (evt.restartdelay);
+                });
+
+                t.equal(trend(deltas.slice(0, cycles_fail - 1)), 1, 'first '
+                    + (cycles_fail - 1) + ' should go up');
+                t.equal(trend(deltas.slice(cycles_fail, deltas.length)), 1,
+                    ' last ' + (deltas.length - cycles_fail) + ' should go up');
+                t.ok((deltas[cycles_fail - 1] > deltas[cycles_fail]),
+                    deltas[cycles_fail - 1] + ' > ' + deltas[cycles_fail]);
+
+                // should be [0, 1, 2, ... 14]
+                for (i = 0; i < num_cycles; i++) {
+                    expected_counts.push(i);
+                }
+
+                // delays should be: [null, 200, 400 ... 12800, 200, ... 12800]
+                for (i = 0; i < cycles_fail; i++) {
+                    expected_delays.push(100 * Math.pow(2, i+1));
+                }
+                for (i = 0; i < cycles_fail; i++) {
+                    expected_delays.push(100 * Math.pow(2, i+1));
+                }
+
+                t.deepEqual(restartcounts, expected_counts,
+                    'check docker:restartcount');
+                t.deepEqual(restartdelays.slice(1), expected_delays,
+                    'check docker:restartdelay');
+
+                cb();
+            });
+        }, function (cb) {
+            // stop the zoneevent watcher
+            if (se != null) {
+                se.stop();
+                se = null;
+            }
+            cb();
+        }
+    ]);
 });


### PR DESCRIPTION
…elay reset

This adds a new internal_metadata property 'docker:restartdelay' which gets set when *starting* a zone and will be used for the *next* start.

When vmadmd is going to restart a zone, it loads the restartdelay if there is one. It also loads the lastbooted and lastexited files which allow us to determine how long the VM was running. If the VM was running for longer than 10 seconds, we use the minimum delay (100ms) and set the docker:restartdelay to 200 (for the next restart). If the VM was running less than 10 seconds, or we cannot determine the runtime, we first look for the restartdelay. If that's not set, we use `100 * Math.pow(2, restartcount)` which which matches what docker does.

This commit also adds a test which exercises this functionality. It boots a docker zone with a cmd that exits some number of times immediately so we're under the 10 second limit and the delay should be increasing. Then it does a sleep 15 and exits and starts this pattern over. This way we can ensure:

 * the restartcount increases each time
 * the restartdelay increases until it's up 15 seconds, then is reset
 * the restartdelay increases again after reset
 * the VM is actually being restarted and the delays are actually (mostly) increasing

The actual boot delay is pretty variable because of all the steps involved when booting the zone. As such, the small delays are often hidden in the noise. That's why we allow it to double 7 times, to ensure that it's actually growing.