### PR TITLE
OS-5160  failure to create zone control file cascades into dumping core due to unchecked undefined callback

### DIFF
--- a/src/vm/lib/metadata/agent.js
+++ b/src/vm/lib/metadata/agent.js
@@ -73,7 +73,7 @@ var MetadataAgent = module.exports = function (options) {
  * information stays in memory for all known VMs so that it can be pulled from
  * core files. For example:
  *
- * > ::findjsobjects -p zonesDebug -p zoneConnections | ::jsprint -d4 zonesDebug
+ * > ::findjsobjects -p zonesDebug | ::jsprint -d4 zonesDebug
  * {
  *   "4149818f-44d1-4798-875c-ff37aec11042": {
  *       "last_zone_load": 1455735290175 (2016 Feb 17 18:54:50),
@@ -651,7 +651,7 @@ function attemptCreateZoneSocket(self, zopts, waitSecs) {
                         + e.message);
                 }
             },
-            fd: fd
+            fd: fd // so it's in the core for debugging
         };
 
         server.on('error', function (err) {

--- a/src/vm/lib/metadata/agent.js
+++ b/src/vm/lib/metadata/agent.js
@@ -294,15 +294,17 @@ MetadataAgent.prototype.start = function () {
                         + error.message);
                     return;
                 }
-                if (!self.zlog[msg.zonename]) {
-                    // create a logger specific to this VM
-                    self.createZoneLog(self.zones[msg.zonename].brand,
-                        msg.zonename);
-                }
+
                 // If the zone was not deleted between the time we saw it start
                 // and now, (we did a vmadm lookup in between via updateZone)
-                // we'll attempt to create the metadata socket.
+                // we'll start the watcher.
                 if (self.zones[msg.zonename]) {
+                    if (!self.zlog[msg.zonename]) {
+                        // create a logger specific to this VM
+                        self.createZoneLog(self.zones[msg.zonename].brand,
+                            msg.zonename);
+                    }
+
                     if (self.zones[msg.zonename].brand === 'kvm') {
                         self.startKVMSocketServer(msg.zonename);
                     } else {

--- a/src/vm/lib/metadata/agent.js
+++ b/src/vm/lib/metadata/agent.js
@@ -301,7 +301,7 @@ MetadataAgent.prototype.start = function () {
                 }
                 // If the zone was not deleted between the time we saw it start
                 // and now, (we did a vmadm lookup in between via updateZone)
-                // we'll start the watcher.
+                // we'll attempt to create the metadata socket.
                 if (self.zones[msg.zonename]) {
                     if (self.zones[msg.zonename].brand === 'kvm') {
                         self.startKVMSocketServer(msg.zonename);

--- a/src/vm/lib/metadata/agent.js
+++ b/src/vm/lib/metadata/agent.js
@@ -120,7 +120,7 @@ MetadataAgent.prototype.createZoneLog = function (type, zonename) {
 
     self.zlog[zonename] = self.log.child({
         brand: type,
-        streams: [{level: 'trace', type: 'raw', stream: newRingbuffer}],
+        streams: [ {level: 'trace', type: 'raw', stream: newRingbuffer} ],
         zonename: zonename});
     self.addDebug(zonename, 'last_10_logs', newRingbuffer.records);
 

--- a/src/vm/sbin/metadata.js
+++ b/src/vm/sbin/metadata.js
@@ -20,13 +20,6 @@ setImmediate(function _startAgent() {
     agent.start();
 });
 
-process.on('uncaughtException', function (error) {
-    log.fatal('Uncaught exception in agent: ' + error.message);
-    log.fatal(error.stack);
-    agent.stop();
-    process.exit(1);
-});
-
 process.on('exit', function () {
     log.info('Agent exiting');
     agent.stop();


### PR DESCRIPTION
This changes the directory creation so that it happens where we can do a retry.

It also adds a number of additional pieces of debugging information that will be available in cores.