### PR TITLE
non-zoneroot updates should work even when zoneroot is full

### DIFF
--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -2746,14 +2746,22 @@ function saveMetadata(payload, log, callback)
     if (payload.hasOwnProperty('tags')) {
         payload.set_tags = payload.tags;
         delete payload.tags;
+    } else {
+        payload.set_tags = {};
     }
+
     if (payload.hasOwnProperty('customer_metadata')) {
         payload.set_customer_metadata = payload.customer_metadata;
         delete payload.customer_metadata;
+    } else {
+        payload.set_customer_metadata = {};
     }
+
     if (payload.hasOwnProperty('internal_metadata')) {
         payload.set_internal_metadata = payload.internal_metadata;
         delete payload.internal_metadata;
+    } else {
+        payload.set_internal_metadata = {};
     }
 
     updateMetadata(protovm, payload, log, callback);

--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -2594,6 +2594,7 @@ function updateMetadata(vmobj, payload, log, callback)
     var key;
     var mdata = {};
     var mdata_filename;
+    var needUpdate = false;
     var tags = {};
     var tags_filename;
     var tracers_obj;
@@ -2605,6 +2606,26 @@ function updateMetadata(vmobj, payload, log, callback)
         tracers_obj = traceUntilCallback('update-metadata', log, callback);
         callback = tracers_obj.callback;
         log = tracers_obj.log;
+    }
+
+    // If no updates to metadata are in the payload, don't do an update.
+    [
+        'remove_customer_metadata',
+        'set_customer_metadata',
+        'remove_internal_metadata',
+        'set_internal_metadata',
+        'remove_tags',
+        'set_tags'
+    ].forEach(function _checkNeedMdataUpdate(field) {
+        if (payload.hasOwnProperty(field)) {
+            needUpdate = true;
+        }
+    });
+
+    if (!needUpdate) {
+        log.debug('No metadata/tags update necessary, skipping.');
+        callback();
+        return;
     }
 
     if (vmobj.hasOwnProperty('zonepath')) {
@@ -2743,6 +2764,7 @@ function updateRoutes(vmobj, payload, log, callback)
 {
     var filename;
     var key;
+    var needUpdate = false;
     var routes = {};
     var tracers_obj;
     var zonepath;
@@ -2753,6 +2775,22 @@ function updateRoutes(vmobj, payload, log, callback)
         tracers_obj = traceUntilCallback('update-routes', log, callback);
         callback = tracers_obj.callback;
         log = tracers_obj.log;
+    }
+
+    // If no updates to routes are in the payload, don't do an update.
+    [
+        'remove_routes',
+        'set_routes'
+    ].forEach(function _checkNeedMdataUpdate(field) {
+        if (payload.hasOwnProperty(field)) {
+            needUpdate = true;
+        }
+    });
+
+    if (!needUpdate) {
+        log.debug('No routes update necessary, skipping.');
+        callback();
+        return;
     }
 
     if (vmobj.hasOwnProperty('zonepath')) {

--- a/src/vm/tests/test-update.js
+++ b/src/vm/tests/test-update.js
@@ -16,6 +16,8 @@ require('nodeunit-plus');
 
 VM.loglevel = 'DEBUG';
 
+var afterVmobj = {};
+var beforeVmobj;
 var image_uuid = vmtest.CURRENT_SMARTOS_UUID;
 var vm_uuid;
 
@@ -1195,6 +1197,87 @@ test('remove cpu_cap', function (t) {
                 t.end();
             });
         });
+    });
+});
+
+/*
+ * For this next set of tests, we fill up the zone's quota so that we can't
+ * write any data in the zoneroot. We then test that updates other than
+ * routes/tags/metadata (which operate inside the zoneroot) work. (See OS-3191)
+ */
+
+test('set low quota', function (t) {
+    VM.update(vm_uuid, {quota: 1}, function (update_err) {
+        t.ok(!update_err, 'update quota=1: '
+            + (update_err ? update_err.message : 'success'));
+        t.end();
+    });
+});
+
+test('fill up zoneroot', function (t) {
+    execFile('/usr/bin/dd', [
+        'if=/dev/zero',
+        'of=/zones/' + vm_uuid + '/root/zeros',
+        'bs=1M'
+    ], function (err, stdout, stderr) {
+        var match = stderr.match(/dd: unexpected short write, wrote/);
+        t.ok(match, 'expected short write' + (match ? '' : JSON.stringify(stderr)));
+        t.end();
+    });
+});
+
+test('get vmobj for full VM', function (t) {
+    VM.load(vm_uuid, function (err, obj) {
+        t.ok(!err, 'load VM: ' + (err ? err.message : 'success'));
+
+        if (!err) {
+            beforeVmobj = obj;
+        }
+
+        t.end();
+    });
+});
+
+// modifies only /etc/zones/*.xml, so should succeed with full zoneroot
+test('bump max_physical_memory', function (t) {
+    if (beforeVmobj) {
+        var newMaxPhysical = beforeVmobj.max_physical_memory + 1024;
+
+        VM.update(vm_uuid, {
+            max_physical_memory: newMaxPhysical
+        }, function _updateCb(err) {
+            t.ok(!err, 'update max_physical_memory: '
+                + (err ? err.message : 'success'));
+            afterVmobj.max_physical_memory = newMaxPhysical;
+            t.end();
+        });
+    } else {
+        t.end();
+    }
+});
+
+// modifies only zfs dataset, so should succeed with full zoneroot
+test('raise quota to 2', function (t) {
+    VM.update(vm_uuid, {quota: 2}, function (err) {
+        t.ok(!err, 'update quota=2: '
+            + (err ? err.message : 'success'));
+        afterVmobj.quota = 2;
+        t.end();
+    });
+});
+
+test('get vmobj for full VM after modifications', function (t) {
+    VM.load(vm_uuid, function (err, obj) {
+        t.ok(!err, 'load VM: ' + (err ? err.message : 'success'));
+
+        if (!err) {
+            Object.keys(afterVmobj).forEach(function _cmpKey(k) {
+                t.equal(JSON.stringify(afterVmobj[k]), JSON.stringify(obj[k]),
+                    'check ' + k);
+            });
+        }
+
+        t.end();
     });
 });
 

--- a/src/vm/tests/test-update.js
+++ b/src/vm/tests/test-update.js
@@ -1221,7 +1221,8 @@ test('fill up zoneroot', function (t) {
         'bs=1M'
     ], function (err, stdout, stderr) {
         var match = stderr.match(/dd: unexpected short write, wrote/);
-        t.ok(match, 'expected short write' + (match ? '' : JSON.stringify(stderr)));
+        t.ok(match, 'expected short write'
+            + (match ? '' : JSON.stringify(stderr)));
         t.end();
     });
 });
@@ -1238,7 +1239,7 @@ test('get vmobj for full VM', function (t) {
     });
 });
 
-// modifies only /etc/zones/*.xml, so should succeed with full zoneroot
+// modifies only /etc/zones/<uuid>.xml, so should succeed with full zoneroot
 test('bump max_physical_memory', function (t) {
     if (beforeVmobj) {
         var newMaxPhysical = beforeVmobj.max_physical_memory + 1024;


### PR DESCRIPTION
This changes so we don't try to update the metadata.json, tags.json or routes.json unless the payload included updates to those.

It also adds tests that the quota and max_physical_memory are updatable on a full zone. These two are representative of a change to zfs (quota) and the zonecfg (max_physical_memory) and fail without the VM.js changes.