### PR TITLE
OS-5237 reuse the vmadmd watcher instead of spinning up a new zoneevent for e…

### DIFF
--- a/src/node_modules/assert-plus.js
+++ b/src/node_modules/assert-plus.js
@@ -1,245 +1,211 @@
 // Copyright (c) 2012, Mark Cavage. All rights reserved.
+// Copyright 2015 Joyent, Inc.
 
 var assert = require('assert');
 var Stream = require('stream').Stream;
 var util = require('util');
 
 
-
 ///--- Globals
 
-var NDEBUG = process.env.NODE_NDEBUG || false;
+/* JSSTYLED */
 var UUID_REGEXP = /^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/;
-
-
-
-///--- Messages
-
-var ARRAY_TYPE_REQUIRED = '%s ([%s]) required';
-var TYPE_REQUIRED = '%s (%s) is required';
-
 
 
 ///--- Internal
 
-function capitalize(str) {
-        return (str.charAt(0).toUpperCase() + str.slice(1));
+function _capitalize(str) {
+    return (str.charAt(0).toUpperCase() + str.slice(1));
 }
 
-function uncapitalize(str) {
-        return (str.charAt(0).toLowerCase() + str.slice(1));
+function _toss(name, expected, oper, arg, actual) {
+    throw new assert.AssertionError({
+        message: util.format('%s (%s) is required', name, expected),
+        actual: (actual === undefined) ? typeof (arg) : actual(arg),
+        expected: expected,
+        operator: oper || '===',
+        stackStartFunction: _toss.caller
+    });
 }
 
-function _() {
-        return (util.format.apply(util, arguments));
+function _getClass(arg) {
+    return (Object.prototype.toString.call(arg).slice(8, -1));
 }
 
-
-function _assert(arg, type, name, stackFunc) {
-        if (!NDEBUG) {
-                name = name || type;
-                stackFunc = stackFunc || _assert.caller;
-                var t = typeof (arg);
-
-                if (t !== type) {
-                        throw new assert.AssertionError({
-                                message: _(TYPE_REQUIRED, name, type),
-                                actual: t,
-                                expected: type,
-                                operator: '===',
-                                stackStartFunction: stackFunc
-                        });
-                }
-        }
-}
-
-
-function _instanceof(arg, type, name, stackFunc) {
-        if (!NDEBUG) {
-                name = name || type;
-                stackFunc = stackFunc || _instanceof.caller;
-
-                if (!(arg instanceof type)) {
-                        throw new assert.AssertionError({
-                                message: _(TYPE_REQUIRED, name, type.name),
-                                actual: _getClass(arg),
-                                expected: type.name,
-                                operator: 'instanceof',
-                                stackStartFunction: stackFunc
-                        });
-                }
-        }
-}
-
-function _getClass(object) {
-        return (Object.prototype.toString.call(object).slice(8, -1));
-};
-
-
-
-///--- API
-
-function array(arr, type, name) {
-        if (!NDEBUG) {
-                name = name || type;
-
-                if (!Array.isArray(arr)) {
-                        throw new assert.AssertionError({
-                                message: _(ARRAY_TYPE_REQUIRED, name, type),
-                                actual: typeof (arr),
-                                expected: 'array',
-                                operator: 'Array.isArray',
-                                stackStartFunction: array.caller
-                        });
-                }
-
-                for (var i = 0; i < arr.length; i++) {
-                        _assert(arr[i], type, name, array);
-                }
-        }
-}
-
-
-function bool(arg, name) {
-        _assert(arg, 'boolean', name, bool);
-}
-
-
-function buffer(arg, name) {
-        if (!Buffer.isBuffer(arg)) {
-                throw new assert.AssertionError({
-                        message: _(TYPE_REQUIRED, name || '', 'Buffer'),
-                        actual: typeof (arg),
-                        expected: 'buffer',
-                        operator: 'Buffer.isBuffer',
-                        stackStartFunction: buffer
-                });
-        }
-}
-
-
-function func(arg, name) {
-        _assert(arg, 'function', name);
-}
-
-
-function number(arg, name) {
-        _assert(arg, 'number', name);
-        if (!NDEBUG && (isNaN(arg) || !isFinite(arg))) {
-                throw new assert.AssertionError({
-                        message: _(TYPE_REQUIRED, name, 'number'),
-                        actual: arg,
-                        expected: 'number',
-                        operator: 'isNaN',
-                        stackStartFunction: number
-                });
-        }
-}
-
-
-function object(arg, name) {
-        _assert(arg, 'object', name);
-}
-
-
-function stream(arg, name) {
-        _instanceof(arg, Stream, name);
-}
-
-
-function date(arg, name) {
-        _instanceof(arg, Date, name);
-}
-
-function regexp(arg, name) {
-        _instanceof(arg, RegExp, name);
-}
-
-
-function string(arg, name) {
-        _assert(arg, 'string', name);
-}
-
-
-function uuid(arg, name) {
-        string(arg, name);
-        if (!NDEBUG && !UUID_REGEXP.test(arg)) {
-                throw new assert.AssertionError({
-                        message: _(TYPE_REQUIRED, name, 'uuid'),
-                        actual: 'string',
-                        expected: 'uuid',
-                        operator: 'test',
-                        stackStartFunction: uuid
-                });
-        }
+function noop() {
+    // Why even bother with asserts?
 }
 
 
 ///--- Exports
 
-module.exports = {
-        bool: bool,
-        buffer: buffer,
-        date: date,
-        func: func,
-        number: number,
-        object: object,
-        regexp: regexp,
-        stream: stream,
-        string: string,
-        uuid: uuid
+var types = {
+    bool: {
+        check: function (arg) { return typeof (arg) === 'boolean'; }
+    },
+    func: {
+        check: function (arg) { return typeof (arg) === 'function'; }
+    },
+    string: {
+        check: function (arg) { return typeof (arg) === 'string'; }
+    },
+    object: {
+        check: function (arg) {
+            return typeof (arg) === 'object' && arg !== null;
+        }
+    },
+    number: {
+        check: function (arg) {
+            return typeof (arg) === 'number' && !isNaN(arg);
+        }
+    },
+    finite: {
+        check: function (arg) {
+            return typeof (arg) === 'number' && !isNaN(arg) && isFinite(arg);
+        }
+    },
+    buffer: {
+        check: function (arg) { return Buffer.isBuffer(arg); },
+        operator: 'Buffer.isBuffer'
+    },
+    array: {
+        check: function (arg) { return Array.isArray(arg); },
+        operator: 'Array.isArray'
+    },
+    stream: {
+        check: function (arg) { return arg instanceof Stream; },
+        operator: 'instanceof',
+        actual: _getClass
+    },
+    date: {
+        check: function (arg) { return arg instanceof Date; },
+        operator: 'instanceof',
+        actual: _getClass
+    },
+    regexp: {
+        check: function (arg) { return arg instanceof RegExp; },
+        operator: 'instanceof',
+        actual: _getClass
+    },
+    uuid: {
+        check: function (arg) {
+            return typeof (arg) === 'string' && UUID_REGEXP.test(arg);
+        },
+        operator: 'isUUID'
+    }
 };
 
+function _setExports(ndebug) {
+    var keys = Object.keys(types);
+    var out;
 
-Object.keys(module.exports).forEach(function (k) {
-        if (k === 'buffer')
-                return;
-
-        var name = 'arrayOf' + capitalize(k);
-
-        if (k === 'bool')
-                k = 'boolean';
-        if (k === 'func')
-                k = 'function';
-        module.exports[name] = function (arg, name) {
-                array(arg, k, name);
+    /* re-export standard assert */
+    if (process.env.NODE_NDEBUG) {
+        out = noop;
+    } else {
+        out = function (arg, msg) {
+            if (!arg) {
+                _toss(msg, 'true', arg);
+            }
         };
-});
+    }
 
-Object.keys(module.exports).forEach(function (k) {
-        var _name = 'optional' + capitalize(k);
-        var s = uncapitalize(k.replace('arrayOf', ''));
-        if (s === 'bool')
-                s = 'boolean';
-        if (s === 'func')
-                s = 'function';
-
-        if (k.indexOf('arrayOf') !== -1) {
-          module.exports[_name] = function (arg, name) {
-                  if (!NDEBUG && arg !== undefined) {
-                          array(arg, s, name);
-                  }
-          };
-        } else {
-          module.exports[_name] = function (arg, name) {
-                  if (!NDEBUG && arg !== undefined) {
-                          _assert(arg, s, name);
-                  }
-          };
+    /* standard checks */
+    keys.forEach(function (k) {
+        if (ndebug) {
+            out[k] = noop;
+            return;
         }
-});
+        var type = types[k];
+        out[k] = function (arg, msg) {
+            if (!type.check(arg)) {
+                _toss(msg, k, type.operator, arg, type.actual);
+            }
+        };
+    });
 
-
-// Reexport built-in assertions
-Object.keys(assert).forEach(function (k) {
-        if (k === 'AssertionError') {
-                module.exports[k] = assert[k];
+    /* optional checks */
+    keys.forEach(function (k) {
+        var name = 'optional' + _capitalize(k);
+        if (ndebug) {
+            out[name] = noop;
+            return;
+        }
+        var type = types[k];
+        out[name] = function (arg, msg) {
+            if (arg === undefined || arg === null) {
                 return;
-        }
+            }
+            if (!type.check(arg)) {
+                _toss(msg, k, type.operator, arg, type.actual);
+            }
+        };
+    });
 
-        module.exports[k] = function () {
-                if (!NDEBUG) {
-                        assert[k].apply(assert[k], arguments);
+    /* arrayOf checks */
+    keys.forEach(function (k) {
+        var name = 'arrayOf' + _capitalize(k);
+        if (ndebug) {
+            out[name] = noop;
+            return;
+        }
+        var type = types[k];
+        var expected = '[' + k + ']';
+        out[name] = function (arg, msg) {
+            if (!Array.isArray(arg)) {
+                _toss(msg, expected, type.operator, arg, type.actual);
+            }
+            var i;
+            for (i = 0; i < arg.length; i++) {
+                if (!type.check(arg[i])) {
+                    _toss(msg, expected, type.operator, arg, type.actual);
                 }
+            }
         };
-});
+    });
+
+    /* optionalArrayOf checks */
+    keys.forEach(function (k) {
+        var name = 'optionalArrayOf' + _capitalize(k);
+        if (ndebug) {
+            out[name] = noop;
+            return;
+        }
+        var type = types[k];
+        var expected = '[' + k + ']';
+        out[name] = function (arg, msg) {
+            if (arg === undefined || arg === null) {
+                return;
+            }
+            if (!Array.isArray(arg)) {
+                _toss(msg, expected, type.operator, arg, type.actual);
+            }
+            var i;
+            for (i = 0; i < arg.length; i++) {
+                if (!type.check(arg[i])) {
+                    _toss(msg, expected, type.operator, arg, type.actual);
+                }
+            }
+        };
+    });
+
+    /* re-export built-in assertions */
+    Object.keys(assert).forEach(function (k) {
+        if (k === 'AssertionError') {
+            out[k] = assert[k];
+            return;
+        }
+        if (ndebug) {
+            out[k] = noop;
+            return;
+        }
+        out[k] = assert[k];
+    });
+
+    /* export ourselves (for unit tests _only_) */
+    out._setExports = _setExports;
+
+    return out;
+}
+
+module.exports = _setExports(process.env.NODE_NDEBUG);

--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -67,8 +67,7 @@
 // Ensure we're using the platform's node
 require('/usr/node/node_modules/platform_node_version').assert();
 
-var assert = require('assert');
-var assert_plus = require('/usr/node/node_modules/assert-plus');
+var assert = require('/usr/node/node_modules/assert-plus');
 var async = require('/usr/node/node_modules/async');
 var bunyan = require('/usr/node/node_modules/bunyan');
 var cp = require('child_process');
@@ -10169,9 +10168,9 @@ exports.delete = function (uuid, options, callback)
 //
 function startZone(vmobj, opts, callback)
 {
-    assert_plus.object(opts, 'opts');
-    assert_plus.object(opts.log, 'opts.log');
-    assert_plus.optionalFunc(opts.state_waiter, 'opts.state_waiter');
+    assert.object(opts, 'opts');
+    assert.object(opts.log, 'opts.log');
+    assert.optionalFunc(opts.state_waiter, 'opts.state_waiter');
 
     var log = opts.log;
     var set_autoboot = 'set autoboot=true';

--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -68,6 +68,7 @@
 require('/usr/node/node_modules/platform_node_version').assert();
 
 var assert = require('assert');
+var assert_plus = require('/usr/node/node_modules/assert-plus');
 var async = require('/usr/node/node_modules/async');
 var bunyan = require('/usr/node/node_modules/bunyan');
 var cp = require('child_process');
@@ -10166,11 +10167,18 @@ exports.delete = function (uuid, options, callback)
 // uuid
 // zonename
 //
-function startZone(vmobj, log, callback)
+function startZone(vmobj, opts, callback)
 {
+    assert_plus.object(opts, 'opts');
+    assert_plus.object(opts.log, 'opts.log');
+    assert_plus.optionalFunc(opts.state_waiter, 'opts.state_waiter');
+
+    var log = opts.log;
     var set_autoboot = 'set autoboot=true';
     var tracers_obj;
     var uuid = vmobj.uuid;
+    var waited = false;
+    var waitErr;
 
     assert(log, 'no logger passed to startZone()');
 
@@ -10192,6 +10200,19 @@ function startZone(vmobj, log, callback)
 
     async.series([
         function (cb) {
+            // If the caller passed a waiting function, start it before we try
+            // booting the VM, since otherwise there'd be a race. We'll just
+            // store the results and poll on it after booting.
+            if (opts.state_waiter) {
+                opts.state_waiter(vmobj.uuid, 'running', {log: log},
+                    function _stateWaiterCb(err) {
+                        waited = true;
+                        waitErr = err;
+                    }
+                );
+            }
+            cb();
+        }, function (cb) {
             // do the booting
             zoneadm(['-u', uuid, 'boot', '-X'], log, function (err, boot_fds) {
                 if (err) {
@@ -10205,7 +10226,21 @@ function startZone(vmobj, log, callback)
                 cb(err);
             });
         }, function (cb) {
-            // ensure it booted
+            // Ensure it booted. If caller passed in a function that can wait
+            // for a zone to go to a state, we'll just call that.
+            if (opts.state_waiter) {
+                function _waitWaiter() {
+                    if (waited) {
+                        cb(waitErr);
+                        return;
+                    }
+                    setTimeout(_waitWaiter, 100);
+                }
+                _waitWaiter();
+                return;
+            }
+
+            // with no opts.state_waiter, we use our own VM.waitForZoneState
             VM.waitForZoneState(vmobj, 'running', {timeout: 30, log: log},
                 function (err, result) {
 
@@ -10713,7 +10748,7 @@ function startVM(vmobj, extra, log, callback)
                 callback(err);
             } else {
                 log.debug('wrote metadata to /tmp/vm.metadata');
-                startZone(vmobj, log, callback);
+                startZone(vmobj, {log: log}, callback);
             }
         }
     );
@@ -11764,7 +11799,10 @@ exports.start = function (uuid, extra, options, callback)
             } else if (['OS', 'LX']
                 .indexOf(BRAND_OPTIONS[vmobj.brand].features.type) !== -1) {
 
-                startZone(vmobj, log, cb);
+                startZone(vmobj, {
+                    log: log,
+                    state_waiter: options.state_waiter
+                }, cb);
             } else {
                 err = new Error('no idea how to start a vm with brand: '
                     + vmobj.brand);

--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -10166,6 +10166,9 @@ exports.delete = function (uuid, options, callback)
 // uuid
 // zonename
 //
+// A state_waiter function can be passed as an option, but this is currently
+// intended only for use with vmadmd and is an internal interface.
+//
 function startZone(vmobj, opts, callback)
 {
     assert.object(opts, 'opts');

--- a/src/vm/sbin/vmadmd.js
+++ b/src/vm/sbin/vmadmd.js
@@ -26,11 +26,12 @@
  */
 
 var assert = require('assert');
+var assert_plus = require('/usr/node/node_modules/assert-plus');
 var async = require('/usr/node/node_modules/async');
 var bunyan = require('/usr/node/node_modules/bunyan');
 var cp = require('child_process');
 var consts = require('constants');
-var events = require('events');
+var EventEmitter = require('events').EventEmitter;
 var execFile = cp.execFile;
 var fs = require('fs');
 var lock = require('/usr/vm/node_modules/locker').lock;
@@ -59,6 +60,7 @@ var vasync = require('vasync');
  */
 var DOCKER_RUNTIME_DELAY_RESET = 10000;
 
+var REPORTED_STATES = ['running', 'stopped'];
 var UPGRADE_SCRIPT = '/smartdc/vm-upgrade/001_upgrade';
 var VMADMD_PORT = 8080;
 var VMADMD_AUTOBOOT_FILE = '/tmp/.autoboot_vmadmd';
@@ -73,14 +75,17 @@ var VNC = {};
 // Global bunyan logger object for use here in vmadmd
 var log;
 
+// Used to keep track of which VMs we're currently delaying a restart for in
+// order to not start additional restarts in that period.
+var restart_waiters = {};
+
 // Used to track which VMs we've seen so that we can update new ones the first
 // time we see them regardless of which zone transition we see for them.  Also
 // stores basic information so we don't have to VM.load() as often.
 var seen_vms = {};
 
-// Used to keep track of which VMs we're currently delaying a restart for in
-// order to not start additional restarts in that period.
-var restart_waiters = {};
+// Used for reporting state changes (running/stopped) to interested listeners
+var stateReporter = new EventEmitter();
 
 
 function sysinfo(callback)
@@ -686,7 +691,8 @@ function restartDockerContainer(uuid, opts)
 
         VM.start(vmobj.uuid, {}, {
             increment_restart_count: true,
-            restart_delay: restart_delay
+            restart_delay: restart_delay,
+            state_waiter: stateWaiter
         }, function (start_err) {
 
             if (start_err) {
@@ -821,6 +827,65 @@ function applyDockerRestartPolicy(vmobj)
     }, restart_delay);
 }
 
+/*
+ * This function waits for a VM (vmUuid) to change to a specified state. It is
+ * passed to VM.start() so that we avoid creating an additional zoneevent
+ * watcher for each, and instead re-use the existing sysevent watcher that we've
+ * already got.
+ */
+function stateWaiter(vmUuid, state, opts, callback) {
+    assert_plus.uuid(vmUuid, 'vmUuid');
+    assert_plus.string(state, 'state');
+    assert_plus.object(opts, 'opts'); // we don't actually use opts though
+    assert_plus.func(callback, 'callback');
+
+    assert_plus.ok(REPORTED_STATES.indexOf(state) !== -1, 'state must be one '
+        + 'of: ' + JSON.stringify(REPORTED_STATES));
+
+    var timeout;
+
+    function _gotState(uuid) {
+        if (uuid === vmUuid) {
+            log.debug({vmUuid: vmUuid, state: state}, 'stateWaiter() saw VM '
+                + 'transition to state');
+            _cleanupWaiter();
+            callback();
+        }
+    }
+
+    function _cleanupWaiter() {
+        clearTimeout(timeout);
+        stateReporter.removeListener(state, _gotState);
+        log.trace({
+            count: EventEmitter.listenerCount(stateReporter, state),
+            state: state,
+            vmUuid: vmUuid
+        }, 'stateReporter listeners after cleanup');
+    }
+
+    stateReporter.on(state, _gotState);
+
+    log.trace({
+        count: EventEmitter.listenerCount(stateReporter, state),
+        state: state,
+        vmUuid: vmUuid
+    }, 'stateReporter listeners after registering');
+
+    timeout = setTimeout(function _onTimeout() {
+        var err = new Error('Timeout waiting for ' + vmUuid + ' transition to '
+            + state);
+
+        log.error({
+            err: err,
+            state: state,
+            vmUuid: vmUuid
+        }, 'timeout waiting for transition');
+
+        _cleanupWaiter();
+        callback(err);
+    }, 30000);
+}
+
 // NOTE: nobody's paying attention to whether this completes or not.
 function updateZoneStatus(ev)
 {
@@ -848,6 +913,15 @@ function updateZoneStatus(ev)
         log.debug({old: ev.oldstate, new: ev.newstate},
             'ignoring state transitions before first boot');
         return;
+    }
+
+    // Report state changes to listeners
+    if (ev.newstate === 'running') {
+        log.trace('emitting: running, ' + ev.zonename);
+        stateReporter.emit('running', ev.zonename);
+    } else if (ev.newstate === 'uninitialized') {
+        log.trace('emitting: stopped, ' + ev.zonename);
+        stateReporter.emit('stopped', ev.zonename);
     }
 
     /*

--- a/src/vm/sbin/vmadmd.js
+++ b/src/vm/sbin/vmadmd.js
@@ -25,8 +25,7 @@
  *
  */
 
-var assert = require('assert');
-var assert_plus = require('/usr/node/node_modules/assert-plus');
+var assert = require('/usr/node/node_modules/assert-plus');
 var async = require('/usr/node/node_modules/async');
 var bunyan = require('/usr/node/node_modules/bunyan');
 var cp = require('child_process');
@@ -834,12 +833,12 @@ function applyDockerRestartPolicy(vmobj)
  * already got.
  */
 function stateWaiter(vmUuid, state, opts, callback) {
-    assert_plus.uuid(vmUuid, 'vmUuid');
-    assert_plus.string(state, 'state');
-    assert_plus.object(opts, 'opts'); // we don't actually use opts though
-    assert_plus.func(callback, 'callback');
+    assert.uuid(vmUuid, 'vmUuid');
+    assert.string(state, 'state');
+    assert.object(opts, 'opts'); // we don't actually use opts though
+    assert.func(callback, 'callback');
 
-    assert_plus.ok(REPORTED_STATES.indexOf(state) !== -1, 'state must be one '
+    assert.ok(REPORTED_STATES.indexOf(state) !== -1, 'state must be one '
         + 'of: ' + JSON.stringify(REPORTED_STATES));
 
     var timeout;


### PR DESCRIPTION
…very VM.start()

By reusing the sysevent watcher, we avoid creating a separate zoneevent for each VM.start(). We also avoid the orphaning of these zoneevent processes which happened because the way we created them was not reentrant.