### PR TITLE
OS-5361 zfd device creation is async. Retry if they're not there initially.

### DIFF
--- a/src/dockerinit/src/dockerinit.c
+++ b/src/dockerinit/src/dockerinit.c
@@ -253,7 +253,7 @@ zfd_ready()
     }
 }
 
-int
+static int
 zfd_open(const char *path, int oflag)
 {
     int fd;


### PR DESCRIPTION
This changes so that whenever we open a zfd device from dockerinit we retry when the device does not exist yet. It also adds some debugging as to how long we waited in zfd_ready() and changes so that if the user has requested to open stdin and we can't open stdin after ZFD_OPEN_RETRIES, we fail instead of starting the user's init with /dev/null as stdin.
