### PR TITLE
fix build followed the wiki

### DIFF
--- a/tools/tzcheck/Makefile
+++ b/tools/tzcheck/Makefile
@@ -29,6 +29,7 @@ SRC =		$(OBJECTS:%=.o%.c)
 CFLAGS =					\
 		-Wall -Wextra -Werror 		\
 		-std=c99 			\
+		-D_FILE_OFFSET_BITS=64          \
 		-D__EXTENSIONS__ 		\
 		-D_REENTRANT			\
 		-I../common			\


### PR DESCRIPTION
https://github.com/illumos/illumos-gate/commit/d1151f9bab097777251f26772ebcc50468637a12 breaks building

```
/usr/include/libcmdutils.h:41:2: error: #error "libcmdutils.h can only be used in a largefile compilation environment"
```