### PR TITLE
Only mount vmsnap checkpoints

### DIFF
--- a/overlay/generic/usr/lib/brand/jcommon/statechange
+++ b/overlay/generic/usr/lib/brand/jcommon/statechange
@@ -603,7 +603,7 @@ setup_snapshots()
 	# internal information, mount the /root directory of each snapshot
 	# separately.
 	#
-	for snap in $(ls -1 $ZONEPATH/.zfs/snapshot); do
+	for snap in $(ls -1 $ZONEPATH/.zfs/snapshot | grep ^vmsnap-); do
 		snapdir=$ZONEPATH/$SNAPSHOT_DIR/$(echo ${snap} | sed -e "s/^vmsnap-//")
 		mkdir -p ${snapdir}
 		mount -F lofs -o ro,setuid,nodevices \


### PR DESCRIPTION
CloudAPI offers a method of managing zfs snapshots. These are prefixed with vmsnap, and are mounted on zone boot via lofs into /checkpoints

However currently, the zone boot code mounts all snapshots via lofs into /checkpoints. This presents issues for snapshots created/deleted in the global zone, that we perhaps don't want automounted or exposed to customers. For example in our use-case, backup snapshots. The main issue here is with snapshot deletion - this leaves broken lofs mounts in the client zone.

By simply mounting vmsnap snapshots only, we avoid this issue whilst retaining compatibility with Triton's CloudAPI snapshot functionality.