### PR TITLE
sysinfo CPU core terminology is confusing

### DIFF
--- a/man/src/sysinfo.1m.md
+++ b/man/src/sysinfo.1m.md
@@ -75,7 +75,7 @@ making changes.
 
     GZ and NGZ
 
-  "CPU Physical Cores"
+  "CPU Physical Processors"
 
     Number of physical CPUs in this host.
 

--- a/src/sysinfo
+++ b/src/sysinfo
@@ -688,7 +688,7 @@ HW_Family='${HW_Family}'
 VM_Capable='${VM_Capable}'
 CPU_Type='${CPU_Version}'
 CPU_Virtualization='${CPU_Virtualization}'
-CPU_Physical_Cores=${CPU_Count}
+CPU_Physical_Processors=${CPU_Count}
 Bhyve_Capable='${Bhyve_Capable}'
 Bhyve_Max_Vcpus=${Bhyve_Max_Vcpus}
 Nic_Tags=${NicTagList}
@@ -828,7 +828,7 @@ END
   "Bhyve Max Vcpus": ${Bhyve_Max_Vcpus},
   "CPU Type": "${CPU_Version}",
   "CPU Virtualization": "${CPU_Virtualization}",
-  "CPU Physical Cores": ${CPU_Count},
+  "CPU Physical Processors": ${CPU_Count},
   "Admin NIC Tag": "${Admin_NIC_Tag}",
 END
     else


### PR DESCRIPTION
The term "core" is confusing here because it is used to describe
both the physical CPU count ("CPU Physical Cores") and the total
number of vCPUs ("CPU Total Cores"). IMO, "physical cores" should
refer to the actual core count, but that is not something that is
currently enumerated.  That may be a followup change.

I propose renaming the physical CPU count as "CPU Physical
Processors" to better communicate what this number represents.