### PR TITLE
OS-8030 vminfod does not offer a way to tell if a vm is fully provisioned

### DIFF
--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -5019,9 +5019,9 @@ function checkPayloadProperties(payload, vmobj, log, callback)
         if (payload.hasOwnProperty('add_disks')
             || payload.hasOwnProperty('remove_disks')) {
 
-            if ((vmobj.state !== 'stopped')
-                || (vmobj.state === 'provisioning'
-                && vmobj.zone_state !== 'installed')) {
+            if (vmobj.state !== 'stopped'
+                && (!(vmobj.state === 'provisioning'
+                && vmobj.zone_state === 'installed'))) {
 
                 callback(new Error('updates to disks are only allowed when '
                     + 'state is "stopped", currently: ' + vmobj.state + ' ('
@@ -5034,9 +5034,9 @@ function checkPayloadProperties(payload, vmobj, log, callback)
         // while running. If there are other parameters to update though we'll
         // reject.
         if (payload.hasOwnProperty('update_disks')) {
-            if ((vmobj.state !== 'stopped')
-                || (vmobj.state === 'provisioning'
-                && vmobj.zone_state !== 'installed')) {
+            if (vmobj.state !== 'stopped'
+                && (!(vmobj.state === 'provisioning'
+                && vmobj.zone_state === 'installed'))) {
 
                 live_ok = true;
 
@@ -5061,7 +5061,7 @@ function checkPayloadProperties(payload, vmobj, log, callback)
                 if (!live_ok) {
                     callback(new Error('at least one specified update to disks '
                         + 'is only allowed when state is "stopped", currently: '
-                        + vmobj.state + ' (' + vmobj.zonestate + ')'));
+                        + vmobj.state + ' (' + vmobj.zone_state + ')'));
                     return;
                 }
             }
@@ -8641,10 +8641,6 @@ function installZone(payload, log, callback)
 
             createHostConfFileMounts(vmobj, createFileOpts, log, cb);
         }, function (cb) {
-            vs.stop();
-            vs = null;
-            cb();
-        }, function (cb) {
             var host_vols = {};
             var to_create = [];
 
@@ -8986,6 +8982,61 @@ function installZone(payload, log, callback)
 
             // Add firewall data if it was included
             addFirewallData(payload, vmobj, log, cb);
+
+        // OS-8030 Use a 'provisioning' marker to allow vminfod to know when
+        // an instance is fully provisioned.
+        }, function (cb) {
+            // Reprovisioning doesn't use the provisioning marker.
+            if (reprovisioning) {
+                cb();
+                return;
+            }
+
+            // All metadata has been written and vminfod now contains the
+            // complete metadata. The vm is completely configured so now remove
+            // the provisioning marker, and be sure vminfod knows about the
+            // provisioning marker removal.
+            var cancelFn;
+
+            vasync.parallel({funcs: [
+                function (cb2) {
+                    var obj = {
+                        uuid: payload.uuid
+                    };
+                    var changes = [
+                        {
+                            path: ['provisioning'],
+                            action: 'removed'
+                        }
+                    ];
+                    var opts = {
+                        timeout: VMINFOD_TIMEOUT,
+                        catchErrors: true
+                    };
+                    cancelFn = vs.watchForChanges(obj, changes, opts, cb2);
+                }, function (cb2) {
+                    var remove_provisioning = 'remove attr name=provisioning';
+                    zonecfg(vmobj.uuid, [remove_provisioning], {log: log},
+                            function (err, fds) {
+                        if (err) {
+                            cancelFn();
+                            log.error({err: err, stdout: fds.stdout,
+                                stderr: fds.stderr},
+                                'zonecfg remove provisioning failed: '
+                                + err.message);
+                            cb2(err);
+                            return;
+                        }
+                        cb2();
+                    });
+                }
+            ]}, cb);
+
+        }, function (cb) {
+            vs.stop();
+            vs = null;
+            cb();
+
         }, function (cb) {
 
             var cancelFn;
@@ -9321,10 +9372,12 @@ function createZone(payload, log, callback)
         + 'set brand=' + payload.brand + '\n'
         + 'set uuid=' + payload.uuid + '\n'
         + 'set ip-type=exclusive\n'
+        + 'add attr; set name="provisioning"; set type=string; set value=true;'
+            + 'end\n'
         + 'add attr; set name="vm-version"; set type=string; set value="'
-        + vm_version + '"; end\n'
+            + vm_version + '"; end\n'
         + 'add attr; set name="create-timestamp"; set type=string; set value="'
-        + create_time + '"; end\n';
+            + create_time + '"; end\n';
 
     if (payload.hasOwnProperty('transition')) {
         // IMPORTANT: this is for internal use only and should not be documented

--- a/src/vm/node_modules/proptable.js
+++ b/src/vm/node_modules/proptable.js
@@ -1583,6 +1583,9 @@ exports.properties = {
         zoneinfo: 'init_pid'
     }, platform_buildstamp: {
         sysinfo: 'Live Image'
+    }, provisioning: {
+        loadValueTranslator: 'utils.fixBoolean',
+        zonexml: 'zone.attr.provisioning'
     }, qemu_extra_opts: {
         loadValueTranslator: 'utils.unbase64',
         payload: {
@@ -1834,7 +1837,7 @@ exports.properties = {
         },
         zonexml: 'zone.attr.spice-port'
     }, state: {
-        load_depends: ['failed', 'transition', 'zone_state']
+        load_depends: ['failed', 'provisioning', 'transition', 'zone_state']
     }, tags: {
         flattenable: 'hash_key',
         json: 'tags',

--- a/src/vm/node_modules/vmload/index.js
+++ b/src/vm/node_modules/vmload/index.js
@@ -912,6 +912,12 @@ function getVmobj(uuid, options, callback)
                     }
                 }
 
+                if (vmobj.state === 'stopped' && vmobj.provisioning === true) {
+                    log.debug('provisioning marker is set - converting '
+                        + 'stopped state to provisioning');
+                    vmobj.state = 'provisioning';
+                }
+
                 /*
                  * If the zone has the 'failed' property it doesn't matter what
                  * other state it might be in, we list its state as 'failed'.

--- a/src/vm/package.json
+++ b/src/vm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmadm",
   "description": "administrative tool(s) for managing VMs",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Joyent (joyent.com)",
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
Test suite is still passing after this change:
```
#
#  TEST COMPLETE IN 4956 SECONDS, SUMMARY:
#
# PASS: 5145 / 5145
#
# log files available in: /tmp/vmtest.1572625585.35075
```