### PR TITLE
OS-8051 OS-8032 blocks ./configure if git output is too big

### DIFF
--- a/configure
+++ b/configure
@@ -117,7 +117,7 @@ function checkout_project
 		fi
 	fi
 
-	git -C ${dir} show -s
+	git -C ${dir} --no-pager show -s
 	git -C ${dir} describe --all --long --dirty | egrep -e '-dirty$' &&
 	    echo "Warning: ${dir} contains uncommitted changes!"
 	echo


### PR DESCRIPTION
Tested by running ./configure on my standard 80x24 terminal window.