### PR TITLE
OS-8061 test fw "vmadm - stats after vmadm_vm1" failure

### DIFF
--- a/src/fw/package.json
+++ b/src/fw/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fw",
   "description": "Administrative tool for managing SmartOS VM firewalls",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "Joyent (joyent.com)",
   "private": true,
   "main": "./lib/fw.js",

--- a/src/fw/test/integration/examples.test.js
+++ b/src/fw/test/integration/examples.test.js
@@ -267,7 +267,7 @@ exports['vmadm'] = {
 
     'stats after vmadm_vm1': function (t) {
         mod_fw.statsContain(t, VMS[0], [
-            'block out quick proto tcp from any to any port = smtp' + KF
+            'block out quick proto tcp from any to any port = smtp' + KS + KF
         ], 'smtp block rule applied', function () {
             return t.done();
         });
@@ -300,7 +300,7 @@ exports['vmadm'] = {
 
     'stats after vmadm_cmd1': function (t) {
         mod_fw.statsContain(t, VMS[0], [
-            'block out quick proto tcp from any to any port = smtp' + KF,
+            'block out quick proto tcp from any to any port = smtp' + KS + KF,
             'pass in quick proto tcp from any to any port = www' + KS + KF,
             'pass in quick proto tcp from any to any port = https' + KS + KF
         ], 'smtp block rule applied', function () {
@@ -349,7 +349,7 @@ exports['vmadm'] = {
 
     'stats after start': function (t) {
         mod_fw.statsContain(t, VMS[0], [
-            'block out quick proto tcp from any to any port = smtp' + KF,
+            'block out quick proto tcp from any to any port = smtp' + KS + KF,
             'pass in quick proto tcp from any to any port = www' + KS + KF,
             'pass in quick proto tcp from any to any port = https' + KS + KF
         ], 'smtp block rule applied', function () {

--- a/src/fw/test/integration/in-zone-enabled.test.js
+++ b/src/fw/test/integration/in-zone-enabled.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2019, Joyent, Inc. All rights reserved.
  *
  * Integration tests for enabling / disabling firewalls in a VM
  */

--- a/src/fw/test/integration/in-zone-enabled.test.js
+++ b/src/fw/test/integration/in-zone-enabled.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2019, Joyent, Inc.
  *
  * Integration tests for enabling / disabling firewalls in a VM
  */

--- a/src/fw/test/integration/ipsec.test.js
+++ b/src/fw/test/integration/ipsec.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Joyent, Inc. All rights reserved.
+ * Copyright 2019 Joyent, Inc.
  *
  * Integration tests for rules that allow IPsec traffic into an instance.
  */

--- a/src/fw/test/integration/ipsec.test.js
+++ b/src/fw/test/integration/ipsec.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2019, Joyent, Inc. All rights reserved.
  *
  * Integration tests for rules that allow IPsec traffic into an instance.
  */

--- a/src/fw/test/integration/ipsec.test.js
+++ b/src/fw/test/integration/ipsec.test.js
@@ -13,8 +13,7 @@ var uuid = require('uuid');
 
 // --- Globals
 
-var KS = ' keep state';
-var KF = ' keep frags';
+var KSKF = ' keep state keep frags';
 
 var d = {
     owner_uuid: uuid.v4()
@@ -95,10 +94,10 @@ exports['create vm and rules'] = {
 
     'check ipf rules': function (t) {
         mod_fw.statsContain(t, d.vm.uuid, [
-            'pass in quick proto ah from any to any' + KF,
-            'pass in quick proto esp from any to any' + KF,
-            'pass in quick proto udp from any to any port = isakmp' + KF,
-            'pass in quick proto udp from any to any port = ipsec-nat-t' + KF
+            'pass in quick proto ah from any to any' + KSKF,
+            'pass in quick proto esp from any to any' + KSKF,
+            'pass in quick proto udp from any to any port = isakmp' + KSKF,
+            'pass in quick proto udp from any to any port = ipsec-nat-t' + KSKF
         ], 'ipsec rules applied', function () {
             t.done();
         });

--- a/src/fw/test/lib/fw.js
+++ b/src/fw/test/lib/fw.js
@@ -18,38 +18,37 @@ var util = require('util');
 /**
  * Test whether the ipf rules show up in 'fwadm status' for a VM
  */
-function statsContain(t, uuid, inLines, inDesc, cb) {
+function statsContain(t, uuid, wantedRules, inDesc, cb) {
     var cmd = 'fwadm stats ' + uuid;
     var desc = inDesc + ': ';
-    // clone the input:
-    var lines = inLines.slice();
 
     mod_cp.exec(cmd, function compareStats(err, stdout, stderr) {
         t.ifError(err, desc + 'error running: ' + cmd);
         t.equal(stderr, '', desc + 'stderr: ' + cmd);
 
-        var rules = [];
+        var vmRules = [];
 
         stdout.split('\n').forEach(function (line) {
             if (line === '') {
                 return;
             }
 
-            var parts = line.split(/\s+/g);
-            parts.shift();
-            var rule = parts.join(' ');
-            var idx = lines.indexOf(rule);
-            if (idx !== -1) {
-                t.ok(true, desc + 'found rule: ' + rule);
-                lines.splice(idx, 1);
-            }
-
-            rules.push(rule);
+            // Sanitize and strip the first word/number off the rule.
+            var rule = line.split(/\s+/g).slice(1).join(' ');
+            vmRules.push(rule);
         });
 
-        t.deepEqual(lines, [], desc + 'found all rules');
-        if (lines.length !== 0) {
-            t.deepEqual(rules, [], desc + 'rules found');
+        var missingRules = wantedRules.filter(function (wantedRule) {
+            // One of the vm rules must match the wanted rule.
+            return vmRules.some(function (vmRule) {
+                return vmRule.indexOf(wantedRule) === 0;
+            }) === false;
+        });
+
+        t.equal(missingRules.length, 0, desc + ' should be 0 missing rules');
+        if (missingRules.length) {
+            t.ok(false, 'Missing rules:\n  ' + missingRules.join('\n  ') +
+                '\nVm rules:\n  ' + vmRules.join('\n  '));
         }
 
         return cb();

--- a/src/fw/test/lib/fw.js
+++ b/src/fw/test/lib/fw.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Joyent, Inc. All rights reserved.
+ * Copyright 2019 Joyent, Inc.
  *
  * Test utilities for running fwadm commands
  */

--- a/src/fw/test/lib/fw.js
+++ b/src/fw/test/lib/fw.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2019, Joyent, Inc. All rights reserved.
  *
  * Test utilities for running fwadm commands
  */
@@ -47,8 +47,8 @@ function statsContain(t, uuid, wantedRules, inDesc, cb) {
 
         t.equal(missingRules.length, 0, desc + ' should be 0 missing rules');
         if (missingRules.length) {
-            t.ok(false, 'Missing rules:\n  ' + missingRules.join('\n  ') +
-                '\nVm rules:\n  ' + vmRules.join('\n  '));
+            t.ok(false, 'Missing rules:\n  ' + missingRules.join('\n  ')
+                + '\nVm rules:\n  ' + vmRules.join('\n  '));
         }
 
         return cb();


### PR DESCRIPTION
Both of these test files:
- test/integration/examples.test.js
- test/integration/ipsec.test.js
pass after this change.

I tweaked the `statsContain()` function to allow the wanted rule to be a prefix of the vm rules (it actually was the other way around before this - the vm rule was a prefix of the wanted rule), which then ignores the set-tag() part of the rule.