### PR TITLE
OS-7317 vmadm "remove_filesystems" is both broken and undocumented

### DIFF
--- a/src/vm/man/vmadm.1m.md
+++ b/src/vm/man/vmadm.1m.md
@@ -422,11 +422,11 @@ tab-complete UUIDs rather than having to type them out for every command.
         The same pattern is used for customer_metadata, internal_metadata and
         routes.
 
-        In the case of nics and disks, there are 3 special objects:
+        In the case of nics, disks, and filesystems, there are 3 special objects:
 
-          add_disks || add_nics
-          remove_disks || remove_nics
-          update_disks || update_nics
+          add_disks || add_nics || add_filesystems
+          remove_disks || remove_nics || remove_filesystems
+          update_disks || update_nics || update_filesystems
 
         For NICs for example, you can include an array of NIC objects with the
         parameter add_nics in your input. Those NICs would get added to the VM.
@@ -437,6 +437,10 @@ tab-complete UUIDs rather than having to type them out for every command.
         and a different MAC, and remove the existing one. To remove a NIC, the
         remove_nics property should be an array of MAC addresses only (not NIC
         objects).
+
+        For updating filesystems, you use the same format as described above for NICs
+        except that the options are add_filesystems, remove_filesystems and update_filesystems
+        and instead of "mac" these will be keyed on "target".
 
         For updating disks, you use the same format as described above for NICs
         except that the options are add_disks, remove_disks and update_disks
@@ -2680,8 +2684,8 @@ stopping
               "gateways": ["10.2.121.1"]
             }
           ]
-      }
-      EOF
+        }
+        EOF
 
     Example 10: Change the IP of the NIC with MAC b2:1e:ba:a5:6e:71 for the VM
                 with the UUID 54f1cc77-68f1-42ab-acac-5c4f64f5d6e0.
@@ -2703,19 +2707,36 @@ stopping
         echo '{"remove_nics": ["b2:1e:ba:a5:6e:71"]}' | \
             vmadm update 54f1cc77-68f1-42ab-acac-5c4f64f5d6e0
 
-    Example 12: Stop VM 54f1cc77-68f1-42ab-acac-5c4f64f5d6e0
+    Example 12: Adding a lofs filesystem mount to the VM 54f1cc77-68f1-42ab-acac-5c4f64f5d6e0
+
+        vmadm update 54f1cc77-68f1-42ab-acac-5c4f64f5d6e0 <<EOF
+        {
+          "add_filesystems": [
+            {
+	      "source": "/bulk/logs/54f1cc77-68f1-42ab-acac-5c4f64f5d6e0",
+	      "target": "/var/log",
+	      "type": "lofs",
+	      "options": [
+	        "nodevice"
+	      ]
+            }
+          ]
+        }
+        EOF
+
+    Example 13: Stop VM 54f1cc77-68f1-42ab-acac-5c4f64f5d6e0
 
         vmadm stop 54f1cc77-68f1-42ab-acac-5c4f64f5d6e0
 
-    Example 13: Start VM 54f1cc77-68f1-42ab-acac-5c4f64f5d6e0
+    Example 14: Start VM 54f1cc77-68f1-42ab-acac-5c4f64f5d6e0
 
         vmadm start 54f1cc77-68f1-42ab-acac-5c4f64f5d6e0
 
-    Example 14: Reboot VM 54f1cc77-68f1-42ab-acac-5c4f64f5d6e0
+    Example 15: Reboot VM 54f1cc77-68f1-42ab-acac-5c4f64f5d6e0
 
         vmadm reboot 54f1cc77-68f1-42ab-acac-5c4f64f5d6e0
 
-    Example 15: Delete VM 54f1cc77-68f1-42ab-acac-5c4f64f5d6e0
+    Example 16: Delete VM 54f1cc77-68f1-42ab-acac-5c4f64f5d6e0
 
         vmadm delete 54f1cc77-68f1-42ab-acac-5c4f64f5d6e0
 

--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -113,6 +113,7 @@ var KEEP_ZERO_PROPERTIES = properties.KEEP_ZERO_PROPERTIES;
 var KVM_MEM_OVERHEAD = properties.KVM_MEM_OVERHEAD;
 var UPDATABLE_DISK_PROPS = properties.UPDATABLE_DISK_PROPS;
 var UPDATABLE_NIC_PROPS = properties.UPDATABLE_NIC_PROPS;
+var UPDATABLE_FILESYSTEM_PROPS = properties.UPDATABLE_FILESYSTEM_PROPS;
 var UPDATABLE_PCI_DEVICE_PROPS = properties.UPDATABLE_PCI_DEVICE_PROPS;
 
 // re-export these
@@ -6389,14 +6390,15 @@ function buildFilesystemZonecfg(vmobj, payload, options)
         options = {};
     }
 
-    lists = buildAddRemoveList(vmobj, payload, 'filesystem', 'target', []);
+    lists = buildAddRemoveList(vmobj, payload, 'filesystem', 'target',
+        UPDATABLE_FILESYSTEM_PROPS);
     remove = lists.remove;
     add = lists.add;
 
-    // remove is a list of disk paths, add a remove for each now.
+    // remove is a list of filesystem paths, add a remove for each now.
     for (filesystem in remove) {
         filesystem = remove[filesystem];
-        zcfg = zcfg + 'remove fs match=' + filesystem + '\n';
+        zcfg = zcfg + 'remove fs dir=' + filesystem + '\n';
     }
 
     for (filesystem in add) {
@@ -6978,7 +6980,7 @@ function buildZonecfgUpdate(vmobj, payload, log)
     if (payload.hasOwnProperty('filesystems')
         || payload.hasOwnProperty('add_filesystems')
         || payload.hasOwnProperty('update_filesystems')
-        || payload.hasOwnProperty('add_filesystems')) {
+        || payload.hasOwnProperty('remove_filesystems')) {
 
         zcfg = zcfg + buildFilesystemZonecfg(vmobj, payload);
     }

--- a/src/vm/node_modules/expander.js
+++ b/src/vm/node_modules/expander.js
@@ -72,6 +72,7 @@ var payload_props = {};
 var sysinfo = {};
 var updatable_disk_props = [];
 var updatable_nic_props = [];
+var updatable_filesystem_props = [];
 var updatable_pci_device_props = [];
 var vmobj_json_fields = [];
 var vmobj_sysinfo_fields = [];
@@ -110,6 +111,11 @@ Object.keys(proptable.properties).forEach(function (prop) {
     match = prop.match(/^disks\.\*\.(.*)$/);
     if (match && property.updatable) {
         updatable_disk_props.push(match[1]);
+    }
+
+    match = prop.match(/^filesystems\.\*\.(.*)$/);
+    if (match && property.updatable) {
+        updatable_filesystem_props.push(match[1]);
     }
 
     match = prop.match(/^pci_devices\.\*\.(.*)$/);
@@ -276,6 +282,8 @@ output = 'exports.VMOBJ_JSON_FIELDS = '
     + JSON.stringify(updatable_disk_props, null, 2) + ';\n\n'
     + 'exports.UPDATABLE_NIC_PROPS = '
     + JSON.stringify(updatable_nic_props, null, 2) + ';\n\n'
+    + 'exports.UPDATABLE_FILESYSTEM_PROPS = '
+    + JSON.stringify(updatable_filesystem_props, null, 2) + ';\n\n'
     + 'exports.UPDATABLE_PCI_DEVICE_PROPS = '
     + JSON.stringify(updatable_pci_device_props, null, 2) + ';\n\n'
     + 'exports.VMOBJ_XML_FIELDS = '

--- a/src/vm/node_modules/proptable.js
+++ b/src/vm/node_modules/proptable.js
@@ -794,51 +794,56 @@ exports.properties = {
     }, 'filesystems.*.options': {
         payload: {
             allowed: {
-                'joyent': ['add'],
-                'joyent-minimal': ['add'],
-                'lx': ['add']
+                'joyent': ['add', 'update'],
+                'joyent-minimal': ['add', 'update'],
+                'lx': ['add', 'update']
             },
             type: 'list'
-        }
+        },
+        updatable: true
     }, 'filesystems.*.raw': {
         payload: {
             allowed: {
-                'joyent': ['add'],
-                'joyent-minimal': ['add'],
-                'lx': ['add']
+                'joyent': ['add', 'update'],
+                'joyent-minimal': ['add', 'update'],
+                'lx': ['add', 'update']
             },
             type: 'string'
         },
+        updatable: true,
         zonexml: 'zone.filesystem.raw'
     }, 'filesystems.*.source': {
         payload: {
             allowed: {
-                'joyent': ['add'],
-                'joyent-minimal': ['add'],
-                'lx': ['add']
+                'joyent': ['add', 'update'],
+                'joyent-minimal': ['add', 'update'],
+                'lx': ['add', 'update']
             },
             type: 'string'
         },
+        updatable: true,
         zonexml: 'zone.filesystem.special'
     }, 'filesystems.*.target': {
         payload: {
             allowed: {
-                'joyent': ['add'],
-                'joyent-minimal': ['add'],
-                'lx': ['add']
+                'joyent': ['add', 'update'],
+                'joyent-minimal': ['add', 'update'],
+                'lx': ['add', 'update']
             },
             type: 'string'
         },
+        updatable: true,
         zonexml: 'zone.filesystem.directory'
     }, 'filesystems.*.type': {
         payload: {
             allowed: {
-                'joyent': ['add'],
-                'joyent-minimal': ['add'],
-                'lx': ['add']
+                'joyent': ['add', 'update'],
+                'joyent-minimal': ['add', 'update'],
+                'lx': ['add', 'update']
             },
             type: 'string'
         },
+        updatable: true,
         zonexml: 'zone.filesystem.type'
     }, firewall_enabled: {
         loadValueTranslator: 'utils.fixBoolean',
@@ -1657,7 +1662,6 @@ exports.properties = {
     }, remove_filesystems: {
         payload: {
             allowed: {
-                // XXX-mg delete?
                 'bhyve': ['update'],
                 'joyent': ['update'],
                 'joyent-minimal': ['update'],

--- a/src/vm/tests/test-update.js
+++ b/src/vm/tests/test-update.js
@@ -258,8 +258,7 @@ var PAYLOADS = {
             }
         ]
     }, remove_fs_tmp_global: {
-        remove_filesystems: [
-	  '/var/tmp/global']
+        remove_filesystems: ['/var/tmp/global']
     }
 };
 
@@ -1487,14 +1486,20 @@ test('add fs /var/tmp/global', function (t) {
                 if (err) {
                     t.ok(false, 'failed reloading VM');
                 } else if (obj.filesystems.length !== 1) {
-                    t.ok(false, 'VM has ' + obj.filesystems.length + ' != 1 filesystem');
+                    t.ok(false, 'VM has ' + obj.filesystems.length
+                        + ' != 1 filesystem');
                 } else {
-                    for (field in PAYLOADS.add_fs_tmp_global.add_filesystems[0]) {
-                        var cmp_value_set = JSON.stringify(obj.filesystems[0][field]);
-                        var cmp_value_payload = JSON.stringify(PAYLOADS.add_fs_tmp_global.add_filesystems[0][field]);
+                    for (field in PAYLOADS.add_fs_tmp_global.
+                        add_filesystems[0]) {
+                        var cmp_value_set = JSON.stringify(
+                            obj.filesystems[0][field]);
+                        var cmp_value_payload = JSON.stringify(PAYLOADS.
+                            add_fs_tmp_global.add_filesystems[0][field]);
                         var cmp_result = (cmp_value_set === cmp_value_payload);
-                        var msg_ok = 'field ' + field + ' was set to ' + cmp_value_set;
-                        var msg_fail = msg_ok + ', but expected value is ' + cmp_value_payload;
+                        var msg_ok = 'field ' + field + ' was set to '
+                            + cmp_value_set;
+                        var msg_fail = msg_ok + ', but expected value is '
+                            + cmp_value_payload;
                         t.ok(cmp_result, cmp_result ? msg_ok : msg_fail);
                     }
                 }
@@ -1516,14 +1521,20 @@ test('set fs /var/tmp/global as readonly', function (t) {
                 if (err) {
                     t.ok(false, 'failed reloading VM');
                 } else if (obj.filesystems.length !== 1) {
-                    t.ok(false, 'VM has ' + obj.filesystems.length + ' != 1 filesystem');
+                    t.ok(false, 'VM has ' + obj.filesystems.length
+                        + ' != 1 filesystem');
                 } else {
-                    for (field in PAYLOADS.update_fs_tmp_global.update_filesystems[0]) {
-                        var cmp_value_set = JSON.stringify(obj.filesystems[0][field]);
-                        var cmp_value_payload = JSON.stringify(PAYLOADS.update_fs_tmp_global.update_filesystems[0][field]);
+                    for (field in PAYLOADS.update_fs_tmp_global.
+                        update_filesystems[0]) {
+                        var cmp_value_set = JSON.stringify(
+                            obj.filesystems[0][field]);
+                        var cmp_value_payload = JSON.stringify(PAYLOADS.
+                            update_fs_tmp_global.update_filesystems[0][field]);
                         var cmp_result = (cmp_value_set === cmp_value_payload);
-                        var msg_ok = 'field ' + field + ' was set to ' + cmp_value_set;
-                        var msg_fail = msg_ok + ', but expected value is ' + cmp_value_payload;
+                        var msg_ok = 'field ' + field + ' was set to '
+                            + cmp_value_set;
+                        var msg_fail = msg_ok + ', but expected value is '
+                            + cmp_value_payload;
                         t.ok(cmp_result, cmp_result ? msg_ok : msg_fail);
                     }
                 }
@@ -1543,7 +1554,8 @@ test('remove fs /var/tmp/global', function (t) {
                 if (err) {
                     t.ok(false, 'failed reloading VM');
                 } else if (obj.hasOwnProperty('filesystems')) {
-                    t.ok(false, 'VM has ' + obj.filesystems.length + ' != 0 filesystems');
+                    t.ok(false, 'VM has ' + obj.filesystems.length
+                        + ' != 0 filesystems');
                 } else {
                     t.ok(true, 'Successfully removed filesystem from VM');
                 }

--- a/src/vm/tests/test-update.js
+++ b/src/vm/tests/test-update.js
@@ -1485,7 +1485,8 @@ test('add fs /var/tmp/global', function (t) {
 
                 if (err) {
                     t.ok(false, 'failed reloading VM');
-                } else if (obj.filesystems.length !== 1) {
+                } else if (obj.filesystems === undefined
+                            || obj.filesystems.length !== 1) {
                     t.ok(false, 'VM has ' + obj.filesystems.length
                         + ' != 1 filesystem');
                 } else {
@@ -1520,7 +1521,8 @@ test('set fs /var/tmp/global as readonly', function (t) {
 
                 if (err) {
                     t.ok(false, 'failed reloading VM');
-                } else if (obj.filesystems.length !== 1) {
+                } else if (obj.filesystems === undefined
+                            || obj.filesystems.length !== 1) {
                     t.ok(false, 'VM has ' + obj.filesystems.length
                         + ' != 1 filesystem');
                 } else {

--- a/src/vm/tests/test-update.js
+++ b/src/vm/tests/test-update.js
@@ -1504,7 +1504,8 @@ test('add fs /var/tmp/global', function (t) {
                                 obj.filesystems[0][field]);
                             var cmp_value_payload = JSON.stringify(PAYLOADS.
                                 add_fs_tmp_global.add_filesystems[0][field]);
-                            var cmp_result = (cmp_value_set === cmp_value_payload);
+                            var cmp_result =
+                                (cmp_value_set === cmp_value_payload);
                             var msg_ok = 'field ' + field + ' was set to '
                                 + cmp_value_set;
                             var msg_fail = msg_ok + ', but expected value is '
@@ -1548,8 +1549,10 @@ test('set fs /var/tmp/global as readonly', function (t) {
                             var cmp_value_set = JSON.stringify(
                                 obj.filesystems[0][field]);
                             var cmp_value_payload = JSON.stringify(PAYLOADS.
-                                update_fs_tmp_global.update_filesystems[0][field]);
-                            var cmp_result = (cmp_value_set === cmp_value_payload);
+                                update_fs_tmp_global.
+                                update_filesystems[0][field]);
+                            var cmp_result =
+                                (cmp_value_set === cmp_value_payload);
                             var msg_ok = 'field ' + field + ' was set to '
                                 + cmp_value_set;
                             var msg_fail = msg_ok + ', but expected value is '

--- a/src/vm/tests/test-update.js
+++ b/src/vm/tests/test-update.js
@@ -1481,11 +1481,11 @@ test('add fs /var/tmp/global', function (t) {
             t.end();
         } else {
             /*
-	     * Sometimes we hit a race in vminfod where two events are
-	     * reversed. This results in intermittend test failures, to
-	     * avoid this we wait for 100ms before continuing, this is
-	     * sufficiant to avoid the issue.
-	     */
+             * Sometimes we hit a race in vminfod where two events are
+             * reversed. This results in intermittent test failures, to
+             * avoid this we wait for 100ms before continuing, this is
+             * sufficient to avoid the issue.
+             */
             setTimeout(function () {
                 VM.load(vm_uuid, function (err, obj) {
                     var field;
@@ -1526,11 +1526,11 @@ test('set fs /var/tmp/global as readonly', function (t) {
             t.end();
         } else {
             /*
-	     * Sometimes we hit a race in vminfod where two events are
-	     * reversed. This results in intermittend test failures, to
-	     * avoid this we wait for 100ms before continuing, this is
-	     * sufficiant to avoid the issue.
-	     */
+             * Sometimes we hit a race in vminfod where two events are
+             * reversed. This results in intermittent test failures, to
+             * avoid this we wait for 100ms before continuing, this is
+             * sufficient to avoid the issue.
+             */
             setTimeout(function () {
                 VM.load(vm_uuid, function (err, obj) {
                     var field;
@@ -1571,11 +1571,11 @@ test('remove fs /var/tmp/global', function (t) {
             t.end();
         } else {
             /*
-	     * Sometimes we hit a race in vminfod where two events are
-	     * reversed. This results in intermittend test failures, to
-	     * avoid this we wait for 100ms before continuing, this is
-	     * sufficiant to avoid the issue.
-	     */
+             * Sometimes we hit a race in vminfod where two events are
+             * reversed. This results in intermittent test failures, to
+             * avoid this we wait for 100ms before continuing, this is
+             * sufficient to avoid the issue.
+             */
             setTimeout(function () {
                 VM.load(vm_uuid, function (err, obj) {
                     if (err) {

--- a/src/vm/tests/test-update.js
+++ b/src/vm/tests/test-update.js
@@ -1480,33 +1480,36 @@ test('add fs /var/tmp/global', function (t) {
             t.ok(false, 'error updating VM: ' + update_err.message);
             t.end();
         } else {
-            VM.load(vm_uuid, function (err, obj) {
-                var field;
+            setTimeout(function () {
+                t.ok(true, 'waited 1s for vminfod');
+                VM.load(vm_uuid, function (err, obj) {
+                    var field;
 
-                if (err) {
-                    t.ok(false, 'failed reloading VM');
-                } else if (obj.filesystems === undefined) {
-                    t.ok(false, 'VM has no filesystems');
-                } else if (obj.filesystems.length !== 1) {
-                    t.ok(false, 'VM has ' + obj.filesystems.length
-                        + ' != 1 filesystem');
-                } else {
-                    for (field in PAYLOADS.add_fs_tmp_global.
-                        add_filesystems[0]) {
-                        var cmp_value_set = JSON.stringify(
-                            obj.filesystems[0][field]);
-                        var cmp_value_payload = JSON.stringify(PAYLOADS.
-                            add_fs_tmp_global.add_filesystems[0][field]);
-                        var cmp_result = (cmp_value_set === cmp_value_payload);
-                        var msg_ok = 'field ' + field + ' was set to '
-                            + cmp_value_set;
-                        var msg_fail = msg_ok + ', but expected value is '
-                            + cmp_value_payload;
-                        t.ok(cmp_result, cmp_result ? msg_ok : msg_fail);
+                    if (err) {
+                        t.ok(false, 'failed reloading VM');
+                    } else if (obj.filesystems === undefined) {
+                        t.ok(false, 'VM has no filesystems');
+                    } else if (obj.filesystems.length !== 1) {
+                        t.ok(false, 'VM has ' + obj.filesystems.length
+                            + ' != 1 filesystem');
+                    } else {
+                        for (field in PAYLOADS.add_fs_tmp_global.
+                            add_filesystems[0]) {
+                            var cmp_value_set = JSON.stringify(
+                                obj.filesystems[0][field]);
+                            var cmp_value_payload = JSON.stringify(PAYLOADS.
+                                add_fs_tmp_global.add_filesystems[0][field]);
+                            var cmp_result = (cmp_value_set === cmp_value_payload);
+                            var msg_ok = 'field ' + field + ' was set to '
+                                + cmp_value_set;
+                            var msg_fail = msg_ok + ', but expected value is '
+                                + cmp_value_payload;
+                            t.ok(cmp_result, cmp_result ? msg_ok : msg_fail);
+                        }
                     }
-                }
-                t.end();
-            });
+                    t.end();
+                });
+            }, 100);
         }
     });
 });
@@ -1517,33 +1520,36 @@ test('set fs /var/tmp/global as readonly', function (t) {
             t.ok(false, 'error updating VM: ' + update_err.message);
             t.end();
         } else {
-            VM.load(vm_uuid, function (err, obj) {
-                var field;
+            setTimeout(function () {
+                t.ok(true, 'waited 1s for vminfod');
+                VM.load(vm_uuid, function (err, obj) {
+                    var field;
 
-                if (err) {
-                    t.ok(false, 'failed reloading VM');
-                } else if (obj.filesystems === undefined) {
-                    t.ok(false, 'VM has no filesystems');
-                } else if (obj.filesystems.length !== 1) {
-                    t.ok(false, 'VM has ' + obj.filesystems.length
-                        + ' != 1 filesystem');
-                } else {
-                    for (field in PAYLOADS.update_fs_tmp_global.
-                        update_filesystems[0]) {
-                        var cmp_value_set = JSON.stringify(
-                            obj.filesystems[0][field]);
-                        var cmp_value_payload = JSON.stringify(PAYLOADS.
-                            update_fs_tmp_global.update_filesystems[0][field]);
-                        var cmp_result = (cmp_value_set === cmp_value_payload);
-                        var msg_ok = 'field ' + field + ' was set to '
-                            + cmp_value_set;
-                        var msg_fail = msg_ok + ', but expected value is '
-                            + cmp_value_payload;
-                        t.ok(cmp_result, cmp_result ? msg_ok : msg_fail);
+                    if (err) {
+                        t.ok(false, 'failed reloading VM');
+                    } else if (obj.filesystems === undefined) {
+                        t.ok(false, 'VM has no filesystems');
+                    } else if (obj.filesystems.length !== 1) {
+                        t.ok(false, 'VM has ' + obj.filesystems.length
+                            + ' != 1 filesystem');
+                    } else {
+                        for (field in PAYLOADS.update_fs_tmp_global.
+                            update_filesystems[0]) {
+                            var cmp_value_set = JSON.stringify(
+                                obj.filesystems[0][field]);
+                            var cmp_value_payload = JSON.stringify(PAYLOADS.
+                                update_fs_tmp_global.update_filesystems[0][field]);
+                            var cmp_result = (cmp_value_set === cmp_value_payload);
+                            var msg_ok = 'field ' + field + ' was set to '
+                                + cmp_value_set;
+                            var msg_fail = msg_ok + ', but expected value is '
+                                + cmp_value_payload;
+                            t.ok(cmp_result, cmp_result ? msg_ok : msg_fail);
+                        }
                     }
-                }
-                t.end();
-            });
+                    t.end();
+                });
+            }, 100);
         }
     });
 });
@@ -1554,17 +1560,20 @@ test('remove fs /var/tmp/global', function (t) {
             t.ok(false, 'error updating VM: ' + update_err.message);
             t.end();
         } else {
-            VM.load(vm_uuid, function (err, obj) {
-                if (err) {
-                    t.ok(false, 'failed reloading VM');
-                } else if (obj.hasOwnProperty('filesystems')) {
-                    t.ok(false, 'VM has ' + obj.filesystems.length
-                        + ' != 0 filesystems');
-                } else {
-                    t.ok(true, 'Successfully removed filesystem from VM');
-                }
-                t.end();
-            });
+            setTimeout(function () {
+                t.ok(true, 'waited 1s for vminfod');
+                VM.load(vm_uuid, function (err, obj) {
+                    if (err) {
+                        t.ok(false, 'failed reloading VM');
+                    } else if (obj.hasOwnProperty('filesystems')) {
+                        t.ok(false, 'VM has ' + obj.filesystems.length
+                            + ' != 0 filesystems');
+                    } else {
+                        t.ok(true, 'Successfully removed filesystem from VM');
+                    }
+                    t.end();
+                });
+            }, 100);
         }
     });
 });

--- a/src/vm/tests/test-update.js
+++ b/src/vm/tests/test-update.js
@@ -1485,8 +1485,9 @@ test('add fs /var/tmp/global', function (t) {
 
                 if (err) {
                     t.ok(false, 'failed reloading VM');
-                } else if (obj.filesystems === undefined
-                            || obj.filesystems.length !== 1) {
+                } else if (obj.filesystems === undefined) {
+                    t.ok(false, 'VM has no filesystems');
+                } else if (obj.filesystems.length !== 1) {
                     t.ok(false, 'VM has ' + obj.filesystems.length
                         + ' != 1 filesystem');
                 } else {
@@ -1521,8 +1522,9 @@ test('set fs /var/tmp/global as readonly', function (t) {
 
                 if (err) {
                     t.ok(false, 'failed reloading VM');
-                } else if (obj.filesystems === undefined
-                            || obj.filesystems.length !== 1) {
+                } else if (obj.filesystems === undefined) {
+                    t.ok(false, 'VM has no filesystems');
+                } else if (obj.filesystems.length !== 1) {
                     t.ok(false, 'VM has ' + obj.filesystems.length
                         + ' != 1 filesystem');
                 } else {

--- a/src/vm/tests/test-update.js
+++ b/src/vm/tests/test-update.js
@@ -1480,8 +1480,13 @@ test('add fs /var/tmp/global', function (t) {
             t.ok(false, 'error updating VM: ' + update_err.message);
             t.end();
         } else {
+            /*
+	     * Sometimes we hit a race in vminfod where two events are
+	     * reversed. This results in intermittend test failures, to
+	     * avoid this we wait for 100ms before continuing, this is
+	     * sufficiant to avoid the issue.
+	     */
             setTimeout(function () {
-                t.ok(true, 'waited 1s for vminfod');
                 VM.load(vm_uuid, function (err, obj) {
                     var field;
 
@@ -1520,8 +1525,13 @@ test('set fs /var/tmp/global as readonly', function (t) {
             t.ok(false, 'error updating VM: ' + update_err.message);
             t.end();
         } else {
+            /*
+	     * Sometimes we hit a race in vminfod where two events are
+	     * reversed. This results in intermittend test failures, to
+	     * avoid this we wait for 100ms before continuing, this is
+	     * sufficiant to avoid the issue.
+	     */
             setTimeout(function () {
-                t.ok(true, 'waited 1s for vminfod');
                 VM.load(vm_uuid, function (err, obj) {
                     var field;
 
@@ -1560,8 +1570,13 @@ test('remove fs /var/tmp/global', function (t) {
             t.ok(false, 'error updating VM: ' + update_err.message);
             t.end();
         } else {
+            /*
+	     * Sometimes we hit a race in vminfod where two events are
+	     * reversed. This results in intermittend test failures, to
+	     * avoid this we wait for 100ms before continuing, this is
+	     * sufficiant to avoid the issue.
+	     */
             setTimeout(function () {
-                t.ok(true, 'waited 1s for vminfod');
                 VM.load(vm_uuid, function (err, obj) {
                     if (err) {
                         t.ok(false, 'failed reloading VM');


### PR DESCRIPTION
This PR replaces #863

Original work done by @jclulow, man page update + tests done by @sjorge 

```
[root@00-0c-29-51-55-da /usr/vm/test]# ./runtest tests/test-update.js
# Running tests/test-update.js
Already have "imgapi" image source "https://images.joyent.com", no change
Already have "docker" image source "https://docker.io", no change
TAP version 13
# create VM
ok 1 created VM: 7b64f9ad-f4f7-466f-9046-bca2923a6d95
# add net0
ok 2 failed to set ips, was ["10.254.254.254/24"], expected ["10.254.254.254/24"]
ok 3 failed to set netmask, was "255.255.255.0", expected "255.255.255.0"
ok 4 failed to set nic_tag, was "external", expected "external"
ok 5 failed to set vlan_id, was 0, expected 0
ok 6 failed to set gateways, was ["10.254.254.1"], expected ["10.254.254.1"]
ok 7 failed to set mac, was "01:02:03:04:05:06", expected "01:02:03:04:05:06"
ok 8 failed to set interface, was "net0", expected "net0"
# add IPv6 to net0
ok 9 failed to set ips, was ["10.254.254.254/24","fd00::1/64","addrconf"], expected ["10.254.254.254/24","fd00::1/64","addrconf"]
ok 10 failed to set mac, was "01:02:03:04:05:06", expected "01:02:03:04:05:06"
# add net1 -- bad IP
ok 11 failed to add nic with invalid IP: Invalid IP for NIC: {"nic_tag":"external","vlan_id":0,"mac":"82:b3:5f:c6:74:97","physical":"net1","ips":["10.99.99.12,10.99.99.33,10.99.99.34/24"],"gateways":["10.254.254.1"]}
# add KVM-only property to zone
ok 12 VM has [1 vs. 1] nics
ok 13 allow_unfiltered_promisc is not set
# remove net0
ok 14 Successfully removed net0 from VM
# add net0 and net1
ok 15 failed to set ips, was ["10.254.254.254/24"], expected ["10.254.254.254/24"]
ok 16 failed to set gateways, was ["10.254.254.1"], expected ["10.254.254.1"]
ok 17 failed to set ips, was ["10.254.254.253/24"], expected ["10.254.254.253/24"]
ok 18 failed to set gateways, was ["10.254.254.1"], expected ["10.254.254.1"]
# remove net0 and net1
ok 19 Successfully removed net0 and net1 from VM
# add 3 nics, 2 non-private
ok 20 2nd NIC is primary: true
ok 21 updated VM: 7b64f9ad-f4f7-466f-9046-bca2923a6d95
# remove net1 -- 1st time
ok 22 Successfully removed net1 from VM
ok 23 2nd NIC is primary: true
ok 24 [{"interface":"net0","mac":"01:02:03:04:05:06","vlan_id":0,"nic_tag":"external","gateway":"10.254.254.1","gateways":["10.254.254.1"],"netmask":"255.255.255.0","ip":"10.254.254.254","ips":["10.254.254.254/24"]},{"interface":"net2","mac":"02:03:04:05:06:08","vlan_id":253,"nic_tag":"external","gateway":"169.254.169.1","gateways":["169.254.169.1"],"netmask":"255.255.255.0","ip":"169.254.169.253","ips":["169.254.169.253/24"],"primary":true}]
# remove net0 and net2 -- 1st time
ok 25 Successfully removed net0 and net2 from VM
# add 3 nics, 1 non-private
ok 26 2nd NIC is primary: true
ok 27 updated VM: 7b64f9ad-f4f7-466f-9046-bca2923a6d95
# remove net1 -- 2nd time
ok 28 Successfully removed net0 and net1 from VM
ok 29 1st NIC is primary: true
# remove net0 and net2 -- 2nd time
ok 30 Successfully removed net0 and net2 from VM
# add empty NICs
ok 31 (unnamed assert)
ok 32 (unnamed assert)
ok 33 (unnamed assert)
ok 34 Successfully added empty NICs to VM
ok 35 Successfully added empty NICs to VM
ok 36 Successfully added empty NICs to VM
ok 37 Successfully added empty NICs to VM
# remove empty, primary NIC
ok 38 (unnamed assert)
ok 39 (unnamed assert)
ok 40 (unnamed assert)
# add IPs to empty NIC
ok 41 (unnamed assert)
ok 42 (unnamed assert)
ok 43 (unnamed assert)
ok 44 Successfully removed empty NIC from VM
# remove IPs to make empty NIC
ok 45 (unnamed assert)
ok 46 (unnamed assert)
ok 47 (unnamed assert)
ok 48 Successfully removed "ip" from NIC
ok 49 Successfully removed "ips" from NIC
# clean up from empty tests
ok 50 (unnamed assert)
ok 51 (unnamed assert)
ok 52 Remove last empty NIC from VM
# add NIC with minimal properties
ok 53 failed reloading VM
ok 54 VM has 1 nics, expected: 1
ok 55 prop is expected: interface
ok 56 prop interface is not undefined
ok 57 prop is expected: mac
ok 58 prop mac is not undefined
ok 59 prop is expected: nic_tag
ok 60 prop nic_tag is not undefined
ok 61 prop is expected: ip
ok 62 prop ip is not undefined
ok 63 prop is expected: ips
ok 64 prop ips is not undefined
# set then unset simple properties
ok 65 alias is useless VM, expected: useless VM
ok 66 alias is undefined, expected: undefined
ok 67 billing_id is 9.99, expected: 9.99
ok 68 billing_id is undefined, expected: undefined
ok 69 hostname is hamburgerhelper, expected: hamburgerhelper
ok 70 hostname is undefined, expected: undefined
ok 71 owner_uuid is 36bf401a-28ef-11e1-b4a7-c344deb1a5d6, expected: 36bf401a-28ef-11e1-b4a7-c344deb1a5d6
ok 72 owner_uuid is undefined, expected: undefined
ok 73 package_name is really expensive package, expected: really expensive package
ok 74 package_name is undefined, expected: undefined
ok 75 package_version is XP, expected: XP
ok 76 package_version is undefined, expected: undefined
# update quota
ok 77 updated quota now: 13G vs 13G
# remove quota
ok 78 updated quota now: none vs none
# update ram 512
ok 79 vm.max_physical_memory: 512 expected: 512
ok 80 vm.max_locked_memory: 512 expected: 512
ok 81 vm.max_swap: 512 expected: 512
# update ram 128
ok 82 vm.max_physical_memory: 128 expected: 128
ok 83 vm.max_locked_memory: 128 expected: 128
ok 84 vm.max_swap: 256 expected: 256
# update ram 256
ok 85 vm.max_physical_memory: 256 expected: 256
ok 86 vm.max_locked_memory: 256 expected: 256
ok 87 vm.max_swap: 256 expected: 256
# update ram 64
ok 88 vm.max_physical_memory: 64 expected: 64
ok 89 vm.max_locked_memory: 64 expected: 64
ok 90 vm.max_swap: 256 expected: 256
# update ram 1024
ok 91 vm.max_physical_memory: 1024 expected: 1024
ok 92 vm.max_locked_memory: 1024 expected: 1024
ok 93 vm.max_swap: 1024 expected: 1024
# update max_swap (up)
ok 94 vm.max_swap: 1536 expected: 1536
ok 95 vm.tmpfs: 1024 expected: 1024
ok 96 vm.max_physical_memory: 1024 expected: 1024
ok 97 vm.max_locked_memory: 1024 expected: 1024
# update max_swap (down)
ok 98 vm.max_swap: 1024 expected: 1024
ok 99 vm.tmpfs: 1024 expected: 1024
ok 100 vm.max_physical_memory: 1024 expected: 1024
ok 101 vm.max_locked_memory: 1024 expected: 1024
# update max_physical_memory (up)
ok 102 vm.max_swap: 2048 expected: 2048
ok 103 vm.tmpfs: 2048 expected: 2048
ok 104 vm.max_physical_memory: 2048 expected: 2048
ok 105 vm.max_locked_memory: 2048 expected: 2048
# update max_physical_memory (down)
ok 106 vm.max_swap: 512 expected: 512
ok 107 vm.tmpfs: 512 expected: 512
ok 108 vm.max_physical_memory: 512 expected: 512
ok 109 vm.max_locked_memory: 512 expected: 512
# update max_locked_memory
ok 110 vm.max_swap: 512 expected: 512
ok 111 vm.tmpfs: 512 expected: 512
ok 112 vm.max_physical_memory: 512 expected: 512
ok 113 vm.max_locked_memory: 512 expected: 512
# update resolvers when empty
ok 114 resolvers after update: ["4.2.2.1","4.2.2.2"]
# update resolvers to empty when filled
ok 115 resolvers after update: []
# update resolvers to empty when empty
ok 116 resolvers after update: []
# update shm rctls
ok 117 max_msg_ids value before test: 4096
ok 118 max_sem_ids value before test: 4096
ok 119 max_shm_ids value before test: 4096
ok 120 max_shm_memory value before test: 256
ok 121 max_msg_ids value after test: 3333
ok 122 max_sem_ids value after test: 2332
ok 123 max_shm_ids value after test: 2345
ok 124 max_shm_memory value after test: 1234
# remove cpu_cap
ok 125 cpu_cap is 1600 to start
ok 126 cpu_cap is gone
# set low quota
ok 127 update quota=1: success
# fill up zoneroot
ok 128 expected short write
# get vmobj for full VM
ok 129 load VM: success
# bump max_physical_memory
ok 130 update max_physical_memory: success
# raise quota to 2
ok 131 update quota=2: success
# get vmobj for full VM after modifications
ok 132 load VM: success
ok 133 check max_physical_memory
ok 134 check quota
# attempt to modify unmodifiable properties
ok 135 load VM: success
ok 136 update unmodifiable VM property "brand" to "bogus-brand": success
ok 137 load VM: success
ok 138 value has not been modified (original: "joyent", found "joyent")
ok 139 update unmodifiable VM property "hvm" to "bogus-hvm": success
ok 140 load VM: success
ok 141 value has not been modified (original: false, found false)
ok 142 update unmodifiable VM property "last_modified" to "bogus-last-modified": success
ok 143 update unmodifiable VM property "server_uuid" to "00000000-0000-0000-0000-000000000000": success
ok 144 load VM: success
ok 145 value has not been modified (original: "564d0a56-64f5-ac53-2414-89acd25155da", found "564d0a56-64f5-ac53-2414-89acd25155da")
ok 146 update unmodifiable VM property "uuid" to "00000000-0000-0000-0000-000000000000": success
ok 147 load VM: success
ok 148 value has not been modified (original: "7b64f9ad-f4f7-466f-9046-bca2923a6d95", found "7b64f9ad-f4f7-466f-9046-bca2923a6d95")
ok 149 update unmodifiable VM property "zonename" to "bogus-zonename": success
ok 150 load VM: success
ok 151 value has not been modified (original: "7b64f9ad-f4f7-466f-9046-bca2923a6d95", found "7b64f9ad-f4f7-466f-9046-bca2923a6d95")
ok 152 unmodifiable properties: success
# attempt to remove and set zonecfg properties
ok 153 update VM property "cpu_shares" to undefined: success
ok 154 update VM property "cpu_shares" to 5: success
ok 155 update VM property "cpu_shares" to undefined: success
ok 156 update VM property "cpu_shares" to undefined: success
ok 157 update VM property "limit_priv" to "": success
ok 158 update VM property "limit_priv" to "default": success
ok 159 update VM property "limit_priv" to "default,dtrace_user": success
ok 160 update VM property "limit_priv" to "": success
ok 161 update VM property "limit_priv" to "": success
ok 162 update VM property "max_lwps" to undefined: success
ok 163 update VM property "max_lwps" to 5000: success
ok 164 update VM property "max_lwps" to undefined: success
ok 165 update VM property "max_lwps" to undefined: success
ok 166 update VM property "max_msg_ids" to undefined: success
ok 167 update VM property "max_msg_ids" to 5000: success
ok 168 update VM property "max_msg_ids" to undefined: success
ok 169 update VM property "max_msg_ids" to undefined: success
ok 170 update VM property "max_shm_ids" to undefined: success
ok 171 update VM property "max_shm_ids" to 5000: success
ok 172 update VM property "max_shm_ids" to undefined: success
ok 173 update VM property "max_shm_ids" to undefined: success
ok 174 update VM property "max_shm_memory" to undefined: success
ok 175 update VM property "max_shm_memory" to 5000: success
ok 176 update VM property "max_shm_memory" to undefined: success
ok 177 update VM property "max_shm_memory" to undefined: success
ok 178 update VM property "zfs_io_priority" to undefined: success
ok 179 update VM property "zfs_io_priority" to 50: success
ok 180 update VM property "zfs_io_priority" to undefined: success
ok 181 update VM property "zfs_io_priority" to undefined: success
ok 182 zonecfg properties: success
# add fs /var/tmp/global
ok 183 field type was set to "lofs"
ok 184 field source was set to "/tmp"
ok 185 field target was set to "/var/tmp/global"
ok 186 field options was set to ["nodevice"]
# remove fs /var/tmp/global
ok 187 Successfully removed filesystem from VM
# delete zone
ok 188 deleted VM: 7b64f9ad-f4f7-466f-9046-bca2923a6d95

1..188
# tests 188
# pass  188

# ok
#
# tests/test-update.js TEST COMPLETE IN 67 SECONDS, SUMMARY:
#
# PASS: 188 / 188
#
```

I couldn't get a full ./runtests to complete because under vmware fusion both kvm and bhyve fail.
I verified they also fail in an unmodified PI. There is a iso with the changes available here:
https://pkg.blackdot.be/extras/platform-20191224T122406Z.iso

Aditional testing: been using the original change for a few months now as I was carrying it around as a patch with a few other bits.