### PR TITLE
OS-8068 update the smartos release process to no longer use snaplinks

### DIFF
--- a/tools/build_jenkins
+++ b/tools/build_jenkins
@@ -6,7 +6,7 @@
 #
 
 #
-# Copyright 2019 Joyent, Inc.
+# Copyright 2020 Joyent, Inc.
 #
 
 #
@@ -174,8 +174,8 @@ case "${PLATFORM_BUILD_FLAVOR}" in
 esac
 
 #
-# Update Manta snaplinks for smartos, only if this is a non-debug, release
-# build.
+# Upload artifacts separately for smartos to ~~/public/SmartOS, only if this is
+# non-debug, release build.
 # We check for an empty $PLATFORM_DEBUG_SUFFIX as that gets used as the way to
 # prevent downstream Jenkins builds (e.g. 'platform-gcc4') uploading artifacts
 # to the 'platform' Manta directory, even though they may not strictly be debug

--- a/tools/build_jenkins
+++ b/tools/build_jenkins
@@ -175,7 +175,7 @@ esac
 
 #
 # Upload artifacts separately for smartos to ~~/public/SmartOS, only if this is
-# non-debug, release build.
+# a non-debug, release build.
 # We check for an empty $PLATFORM_DEBUG_SUFFIX as that gets used as the way to
 # prevent downstream Jenkins builds (e.g. 'platform-gcc4') uploading artifacts
 # to the 'platform' Manta directory, even though they may not strictly be debug

--- a/tools/smartos-release
+++ b/tools/smartos-release
@@ -6,13 +6,16 @@
 #
 
 #
-# Copyright 2019 Joyent, Inc.
+# Copyright 2020 Joyent, Inc.
 #
 
 #
-# This script is run as part of the biweekly SmartOS release process, and
-# creates snaplinks in Manta to point ~~/public/SmartOS/<timestamp>/ to the
-# current ~~/public/builds/platform/<release>-<timestamp>/platform directory.
+# This script is run as part of the biweekly SmartOS release process. It
+# creates a 'platform-link' object to ~~/public/SmartOS/<timestamp>/ which
+# contains a Manta path to the location of the build artifacts, for processing
+# by the https://github.com/joyent/smartos-changelog generator, and uploads
+# the 'latest' release artifacts to ~~/public/SmartOS/*-latest.* to preserve
+# compatibility with scripts that expect to find them.
 #
 
 # Update the SmartOS release directory
@@ -54,8 +57,9 @@ function print_help() {
     echo "Usage:"
     echo "  ./tools/smartos-release BRANCH TIMESTAMP"
     echo ""
-    echo "Create snaplinks under /\${MANTA_USER}/public/SmartOS/\${TIMESTAMP}"
-    echo "pointing to objects under /\${MANTA_USER}/public/builds/platform/\${BRANCH}-\${TIMESTAMP}/platform/"
+    echo "Write a 'platform-link' file to /\${MANTA_USER}/public/SmartOS/\${TIMESTAMP}"
+    echo "pointing to /\${MANTA_USER}/public/builds/platform/\${BRANCH}-\${TIMESTAMP}/platform/"
+    echo "and upload *-latest.* files to /\${MANTA_USER}/public/SmartOS/"
 }
 
 
@@ -78,31 +82,40 @@ set -o errexit
 # Note that ${BRANCH} appears only once here as we assume that for release
 # builds, all project branches and smartos-live itself use the same branch
 # name. See $(PUB_BRANCH_DESC) in the top-level Makefile for more details.
-SOURCE=/${MANTA_USER}/public/builds/platform/${BRANCH}-${TIMESTAMP}/platform/
+SOURCE=/${MANTA_USER}/public/builds/platform/${BRANCH}-${TIMESTAMP}/platform
 SMARTOS=/${MANTA_USER}/public/SmartOS
 DESTINATION=${SMARTOS}/${TIMESTAMP}
 
 start_time=$(date +%s)
-echo "Creating release snaplinks under ${DESTINATION}"
+echo "Creating release objects under ${DESTINATION}"
 
 mmkdir -v -p ${DESTINATION}
-mfind ${SOURCE} -t o | while read OBJECT; do
-    mln ${OBJECT} ${DESTINATION}/$(basename ${OBJECT})
-done
+# Add an object pointing to the actual platform Manta directory, along with
+# a html version, for convenience.
+echo ${SOURCE} | mput ${DESTINATION}/platform-link
+echo "
+<html>
+<head><title>SmartOS ${BRANCH}-${TIMESTAMP}</title></head>
+<body>
+<a href='../../builds/platform/${BRANCH}-${TIMESTAMP}/platform/index.html'>
+$BRANCH-$TIMESTAMP artifacts</a>
+</body>
+</html>" | mput -H 'content-type: text/html' ${DESTINATION}/platform-link.html
 
-echo "Updating top level ${SMARTOS} snaplinks"
-mln ${SOURCE}/platform-${BRANCH}-${TIMESTAMP}.tgz ${SMARTOS}/platform-latest.tgz
-mln ${SOURCE}/smartos-${TIMESTAMP}.iso ${SMARTOS}/smartos-latest.iso
-mln ${SOURCE}/smartos-${TIMESTAMP}-USB.img.gz ${SMARTOS}/smartos-latest-USB.img.gz
-mln ${SOURCE}/smartos-${TIMESTAMP}.vmwarevm.tar.gz ${SMARTOS}/smartos-latest.vmwarevm.tar.gz
+echo "Uploading 'latest' ${SMARTOS} objects to ${SMARTOS}"
+BITS=output/bits/platform
+mput -f $BITS/platform-${TIMESTAMP}.tgz ${SMARTOS}/platform-latest.tgz
+mput -f $BITS/output/smartos-${TIMESTAMP}.iso ${SMARTOS}/smartos-latest.iso
+mput -f $BITS/smartos-${TIMESTAMP}-USB.img.gz ${SMARTOS}/smartos-latest-USB.img.gz
+mput -f $BITS/smartos-${TIMESTAMP}.vmwarevm.tar.gz ${SMARTOS}/smartos-latest.vmwarevm.tar.gz
 
 echo "Updating ${SMARTOS}/latest object"
-echo ${DESTINATION} | mput -v -H 'content-type: text/plain' ${SMARTOS}/latest
+echo ${SOURCE} | mput -v -H 'content-type: text/plain' ${SMARTOS}/latest
 
 # The index.html file referenced here gets created by 'smartos-index'
 echo "<html><head><meta HTTP-EQUIV=\"REFRESH\" content=\"0; url=${SOURCE}/index.html\"></head></html>" | mput -H 'content-type: text/html' ${SMARTOS}/latest.html
 
 end_time=$(date +%s)
 elapsed=$((${end_time} - ${start_time}))
-echo "Creating release snaplinks took ${elapsed} seconds (Manta path=${DESTINATION})"
+echo "Uploading SmartOS release bits took ${elapsed} seconds (Manta path=${DESTINATION})"
 exit 0

--- a/tools/smartos-release
+++ b/tools/smartos-release
@@ -91,20 +91,15 @@ BUILD_FILES="platform-${BRANCH}-${TIMESTAMP}.tgz
     tests-${BRANCH}-${TIMESTAMP}.tgz
     smartos-${TIMESTAMP}.iso
     smartos-${TIMESTAMP}-USB.img.gz
-    smartos-${TIMESTAMP}.vmwarevm.tar.gz"
-
-for file in ${BUILD_FILES}; do
-    mput -f ${BITS}/$file ${SMARTOS_RELEASE}/$file
-done
-
-ADDITIONAL_FILES="SINGLE_USER_ROOT_PASSWORD.txt
+    smartos-${TIMESTAMP}.vmwarevm.tar.gz
+    SINGLE_USER_ROOT_PASSWORD.txt
     build.log
     changelog.txt
     configure-projects
     gitstatus.json
     index.html
     md5sums.txt"
-for file in ${ADDITIONAL_FILES}; do
+for file in ${BUILD_FILES}; do
     mput -f ${BITS}/$file ${SMARTOS_RELEASE}/$file
 done
 

--- a/tools/smartos-release
+++ b/tools/smartos-release
@@ -11,11 +11,11 @@
 
 #
 # This script is run as part of the biweekly SmartOS release process. It
-# creates a 'platform-link' object to ~~/public/SmartOS/<timestamp>/ which
-# contains a Manta path to the location of the build artifacts, for processing
+# uploads the release artifacts from the platform build bits directory to
+# ~~/public/SmartOS/<timestamp>/ , for processing
 # by the https://github.com/joyent/smartos-changelog generator, and uploads
 # the 'latest' release artifacts to ~~/public/SmartOS/*-latest.* to preserve
-# compatibility with scripts that expect to find them.
+# compatibility with scripts that expect to find them there.
 #
 
 # Update the SmartOS release directory
@@ -26,7 +26,6 @@ fi
 
 TOP=$(cd $(dirname $0)/../; pwd)
 PATH=$PATH:${TOP}/node_modules/manta/bin
-
 
 # --- Manta config
 
@@ -39,7 +38,6 @@ fi
 if [[ -z "$MANTA_USER" ]]; then
     export MANTA_USER="Joyent_Dev";
 fi
-
 
 # --- support functions
 
@@ -57,11 +55,10 @@ function print_help() {
     echo "Usage:"
     echo "  ./tools/smartos-release BRANCH TIMESTAMP"
     echo ""
-    echo "Write a 'platform-link' file to /\${MANTA_USER}/public/SmartOS/\${TIMESTAMP}"
-    echo "pointing to /\${MANTA_USER}/public/builds/platform/\${BRANCH}-\${TIMESTAMP}/platform/"
+    echo "Upload build artifacts to /\${MANTA_USER}/public/SmartOS/\${TIMESTAMP}"
+    echo "duplicating content from /\${MANTA_USER}/public/builds/platform/\${BRANCH}-\${TIMESTAMP}/platform/"
     echo "and uploading *-latest.* files to /\${MANTA_USER}/public/SmartOS/"
 }
-
 
 # --- mainline
 
@@ -79,41 +76,46 @@ fi
 
 set -o errexit
 
-# Note that ${BRANCH} appears only once here as we assume that for release
-# builds, all project branches and smartos-live itself use the same branch
-# name. See $(PUB_BRANCH_DESC) in the top-level Makefile for more details.
-SOURCE=/${MANTA_USER}/public/builds/platform/${BRANCH}-${TIMESTAMP}/platform
 SMARTOS=/${MANTA_USER}/public/SmartOS
 SMARTOS_RELEASE=${SMARTOS}/${TIMESTAMP}
+BITS=output/bits/platform
 
 start_time=$(date +%s)
-echo "Creating release objects under ${SMARTOS_RELEASE}"
 
-mmkdir -v -p ${SMARTOS_RELEASE}
-# Add an object pointing to the actual platform Manta directory, along with
-# a html version, for convenience.
-echo ${SOURCE} | mput -H 'content-type: text/plain' ${SMARTOS_RELEASE}/platform-link
-echo "
-<html>
-<head><title>SmartOS ${BRANCH}-${TIMESTAMP}</title></head>
-<body>
-<a href='../../builds/platform/${BRANCH}-${TIMESTAMP}/platform/index.html'>
-$BRANCH-$TIMESTAMP artifacts</a>
-</body>
-</html>" | mput -H 'content-type: text/html' ${SMARTOS_RELEASE}/platform-link.html
+echo "Uploading release objects to ${SMARTOS_RELEASE}"
+mmkdir -p ${SMARTOS_RELEASE}
+
+mput -f $BITS/platform-${BRANCH}-${TIMESTAMP}.tgz ${SMARTOS_RELEASE}/platform-${BRANCH}-${TIMESTAMP}.tgz
+mput -f $BITS/platform-${BRANCH}-${TIMESTAMP}.imgmanifest ${SMARTOS_RELEASE}/platform-${BRANCH}-${TIMESTAMP}.imgmanifest
+mput -f $BITS/boot-${BRANCH}-${TIMESTAMP}.tgz ${SMARTOS_RELEASE}/boot-${BRANCH}-${TIMESTAMP}.tgz
+mput -f $BITS/tests-${BRANCH}-${TIMESTAMP}.tgz ${SMARTOS_RELEASE}/tests-${BRANCH}-${TIMESTAMP}.tgz
+
+mput -f $BITS/smartos-${TIMESTAMP}.iso ${SMARTOS_RELEASE}/smartos-${TIMESTAMP}.iso
+mput -f $BITS/smartos-${TIMESTAMP}-USB.img.gz ${SMARTOS_RELEASE}/smartos-${TIMESTAMP}-USB.img.gz
+mput -f $BITS/smartos-${TIMESTAMP}.vmwarevm.tar.gz ${SMARTOS_RELEASE}/smartos-${TIMESTAMP}.vmwarevm.tar.gz
+
+ADDITIONAL_FILES="SINGLE_USER_ROOT_PASSWORD.txt
+    build.log
+    changelog.txt
+    configure-projects
+    gitstatus.json
+    index.html
+    md5sums.txt"
+for file in $ADDITIONAL_FILES; do
+    mput -f $BITS/$file ${SMARTOS_RELEASE}/$file
+done
 
 echo "Uploading 'latest' ${SMARTOS} objects to ${SMARTOS}"
-BITS=output/bits/platform
-mput -f $BITS/platform-${TIMESTAMP}.tgz ${SMARTOS}/platform-latest.tgz
-mput -f $BITS/output/smartos-${TIMESTAMP}.iso ${SMARTOS}/smartos-latest.iso
+mput -f $BITS/platform-${BRANCH}-${TIMESTAMP}.tgz ${SMARTOS}/platform-latest.tgz
+mput -f $BITS/smartos-${TIMESTAMP}.iso ${SMARTOS}/smartos-latest.iso
 mput -f $BITS/smartos-${TIMESTAMP}-USB.img.gz ${SMARTOS}/smartos-latest-USB.img.gz
 mput -f $BITS/smartos-${TIMESTAMP}.vmwarevm.tar.gz ${SMARTOS}/smartos-latest.vmwarevm.tar.gz
 
 echo "Updating ${SMARTOS}/latest object"
-echo ${SOURCE} | mput -v -H 'content-type: text/plain' ${SMARTOS}/latest
+echo ${SMARTOS_RELEASE} | mput -H 'content-type: text/plain' ${SMARTOS}/latest
 
 # The index.html file referenced here gets created by 'smartos-index'
-echo "<html><head><meta HTTP-EQUIV=\"REFRESH\" content=\"0; url=${SOURCE}/index.html\"></head></html>" | mput -H 'content-type: text/html' ${SMARTOS}/latest.html
+echo "<html><head><meta HTTP-EQUIV=\"REFRESH\" content=\"0; url=${SMARTOS_RELEASE}/index.html\"></head></html>" | mput -H 'content-type: text/html' ${SMARTOS}/latest.html
 
 end_time=$(date +%s)
 elapsed=$((${end_time} - ${start_time}))

--- a/tools/smartos-release
+++ b/tools/smartos-release
@@ -85,14 +85,17 @@ start_time=$(date +%s)
 echo "Uploading release objects to ${SMARTOS_RELEASE}"
 mmkdir -p ${SMARTOS_RELEASE}
 
-mput -f $BITS/platform-${BRANCH}-${TIMESTAMP}.tgz ${SMARTOS_RELEASE}/platform-${BRANCH}-${TIMESTAMP}.tgz
-mput -f $BITS/platform-${BRANCH}-${TIMESTAMP}.imgmanifest ${SMARTOS_RELEASE}/platform-${BRANCH}-${TIMESTAMP}.imgmanifest
-mput -f $BITS/boot-${BRANCH}-${TIMESTAMP}.tgz ${SMARTOS_RELEASE}/boot-${BRANCH}-${TIMESTAMP}.tgz
-mput -f $BITS/tests-${BRANCH}-${TIMESTAMP}.tgz ${SMARTOS_RELEASE}/tests-${BRANCH}-${TIMESTAMP}.tgz
+BUILD_FILES="platform-${BRANCH}-${TIMESTAMP}.tgz
+    platform-${BRANCH}-${TIMESTAMP}.imgmanifest
+    boot-${BRANCH}-${TIMESTAMP}.tgz
+    tests-${BRANCH}-${TIMESTAMP}.tgz
+    smartos-${TIMESTAMP}.iso
+    smartos-${TIMESTAMP}-USB.img.gz
+    smartos-${TIMESTAMP}.vmwarevm.tar.gz"
 
-mput -f $BITS/smartos-${TIMESTAMP}.iso ${SMARTOS_RELEASE}/smartos-${TIMESTAMP}.iso
-mput -f $BITS/smartos-${TIMESTAMP}-USB.img.gz ${SMARTOS_RELEASE}/smartos-${TIMESTAMP}-USB.img.gz
-mput -f $BITS/smartos-${TIMESTAMP}.vmwarevm.tar.gz ${SMARTOS_RELEASE}/smartos-${TIMESTAMP}.vmwarevm.tar.gz
+for file in ${BUILD_FILES}; do
+    mput -f ${BITS}/$file ${SMARTOS_RELEASE}/$file
+done
 
 ADDITIONAL_FILES="SINGLE_USER_ROOT_PASSWORD.txt
     build.log
@@ -101,8 +104,8 @@ ADDITIONAL_FILES="SINGLE_USER_ROOT_PASSWORD.txt
     gitstatus.json
     index.html
     md5sums.txt"
-for file in $ADDITIONAL_FILES; do
-    mput -f $BITS/$file ${SMARTOS_RELEASE}/$file
+for file in ${ADDITIONAL_FILES}; do
+    mput -f ${BITS}/$file ${SMARTOS_RELEASE}/$file
 done
 
 echo "Uploading 'latest' ${SMARTOS} objects to ${SMARTOS}"

--- a/tools/smartos-release
+++ b/tools/smartos-release
@@ -59,7 +59,7 @@ function print_help() {
     echo ""
     echo "Write a 'platform-link' file to /\${MANTA_USER}/public/SmartOS/\${TIMESTAMP}"
     echo "pointing to /\${MANTA_USER}/public/builds/platform/\${BRANCH}-\${TIMESTAMP}/platform/"
-    echo "and upload *-latest.* files to /\${MANTA_USER}/public/SmartOS/"
+    echo "and uploading *-latest.* files to /\${MANTA_USER}/public/SmartOS/"
 }
 
 
@@ -84,15 +84,15 @@ set -o errexit
 # name. See $(PUB_BRANCH_DESC) in the top-level Makefile for more details.
 SOURCE=/${MANTA_USER}/public/builds/platform/${BRANCH}-${TIMESTAMP}/platform
 SMARTOS=/${MANTA_USER}/public/SmartOS
-DESTINATION=${SMARTOS}/${TIMESTAMP}
+SMARTOS_RELEASE=${SMARTOS}/${TIMESTAMP}
 
 start_time=$(date +%s)
-echo "Creating release objects under ${DESTINATION}"
+echo "Creating release objects under ${SMARTOS_RELEASE}"
 
-mmkdir -v -p ${DESTINATION}
+mmkdir -v -p ${SMARTOS_RELEASE}
 # Add an object pointing to the actual platform Manta directory, along with
 # a html version, for convenience.
-echo ${SOURCE} | mput -H 'content-type: text/plain' ${DESTINATION}/platform-link
+echo ${SOURCE} | mput -H 'content-type: text/plain' ${SMARTOS_RELEASE}/platform-link
 echo "
 <html>
 <head><title>SmartOS ${BRANCH}-${TIMESTAMP}</title></head>
@@ -100,7 +100,7 @@ echo "
 <a href='../../builds/platform/${BRANCH}-${TIMESTAMP}/platform/index.html'>
 $BRANCH-$TIMESTAMP artifacts</a>
 </body>
-</html>" | mput -H 'content-type: text/html' ${DESTINATION}/platform-link.html
+</html>" | mput -H 'content-type: text/html' ${SMARTOS_RELEASE}/platform-link.html
 
 echo "Uploading 'latest' ${SMARTOS} objects to ${SMARTOS}"
 BITS=output/bits/platform
@@ -117,5 +117,5 @@ echo "<html><head><meta HTTP-EQUIV=\"REFRESH\" content=\"0; url=${SOURCE}/index.
 
 end_time=$(date +%s)
 elapsed=$((${end_time} - ${start_time}))
-echo "Uploading SmartOS release bits took ${elapsed} seconds (Manta path=${DESTINATION})"
+echo "Uploading SmartOS release bits took ${elapsed} seconds (Manta path=${SMARTOS_RELEASE})"
 exit 0

--- a/tools/smartos-release
+++ b/tools/smartos-release
@@ -92,7 +92,7 @@ echo "Creating release objects under ${DESTINATION}"
 mmkdir -v -p ${DESTINATION}
 # Add an object pointing to the actual platform Manta directory, along with
 # a html version, for convenience.
-echo ${SOURCE} | mput ${DESTINATION}/platform-link
+echo ${SOURCE} | mput -H 'content-type: text/plain' ${DESTINATION}/platform-link
 echo "
 <html>
 <head><title>SmartOS ${BRANCH}-${TIMESTAMP}</title></head>


### PR DESCRIPTION
A demo of this directory structure, along with corresponding (tweaked to look at ~timf rather than ~Joyent_Dev) smartos-changelog changes from joyent/smartos-change.log#8 is at https://us-east.manta.joyent.com/timf/public/SmartOS/smartos.html with just a single dummy release in /timf/public/SmartOS/20200103T004546Z

The `*-latest*.*` artifacts are not in /timf/public/SmartOS as I created that demo when running the smartos-release script from a workspace that hadn't done a full build.