### PR TITLE
OS-8178 Allow `null` for vmadm(1M) integers to mean the same as the e…

### DIFF
--- a/src/vm/man/vmadm.1m.md
+++ b/src/vm/man/vmadm.1m.md
@@ -2220,7 +2220,7 @@ tab-complete UUIDs rather than having to type them out for every command.
         mechanism to limit the number of filesystems that can be created from
         within the zone. The root user in the GZ is immune to this limit.
 
-        type: integer (0+, set to '' or undefined to unset)
+        type: integer (0+, set to '', null, or undefined to unset)
         vmtype: OS
         listable: no
         create: yes
@@ -2295,7 +2295,7 @@ tab-complete UUIDs rather than having to type them out for every command.
         mechanism to limit the number of snapshots that can be taken from within
         the zone. The root user in the GZ is immune to this limit.
 
-        type: integer (0+, set to '' or undefined to unset)
+        type: integer (0+, set to '', null, or undefined to unset)
         vmtype: OS
         listable: no
         create: yes

--- a/src/vm/man/vmadm.1m.md
+++ b/src/vm/man/vmadm.1m.md
@@ -390,6 +390,15 @@ tab-complete UUIDs rather than having to type them out for every command.
         JSON object on stdin (though it will refuse to work if stdin is a tty),
         or pass property=value arguments on the command line.
 
+	NOTE that property=value arguments may behave differently than JSON
+	objects. For example, using 'zfs_snapshot_limit=null' will fail, but
+	a JSON object of:
+
+          {"zfs_snapshot_limit": null}
+
+	will work.
+
+
         If you pass in a JSON object, that object should be formatted in the
         same manner as a create payload. The only exception is with fields
         that are themselves objects: VM NICs, KVM VM disks, customer_metadata,

--- a/src/vm/man/vmadm.1m.md
+++ b/src/vm/man/vmadm.1m.md
@@ -390,14 +390,13 @@ tab-complete UUIDs rather than having to type them out for every command.
         JSON object on stdin (though it will refuse to work if stdin is a tty),
         or pass property=value arguments on the command line.
 
-	NOTE that property=value arguments may behave differently than JSON
-	objects. For example, using 'zfs_snapshot_limit=null' will fail, but
-	a JSON object of:
+        Many properties can be cleared by specifying their value as null in
+        the JSON, e.g.
 
-          {"zfs_snapshot_limit": null}
+          { ... "zfs_snapshot_limit": null }
 
-	will work.
-
+        However this does not work via a direct `vmadm update UUID prop=null`
+        command.
 
         If you pass in a JSON object, that object should be formatted in the
         same manner as a create payload. The only exception is with fields

--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -9713,8 +9713,8 @@ function normalizePayload(payload, vmobj, log, callback)
                 && PAYLOAD_PROPERTIES[property].pr_type === 'integer'
                 && payload[property] !== undefined) {
                 // undefined is a special case since we use that to unset props
-                // treat empty string as undefined too
-                if (payload[property] === '') {
+                // treat empty string or null as undefined too
+                if (payload[property] === '' || payload[property] === null) {
                     payload[property] = undefined;
                 } else {
                     payload[property] = Number(payload[property]);

--- a/src/vm/tests/test-zfs-limits-null.js
+++ b/src/vm/tests/test-zfs-limits-null.js
@@ -1,0 +1,71 @@
+// Copyright 2020 Joyent, Inc.
+
+var async = require('/usr/node/node_modules/async');
+var exec = require('child_process').exec;
+var fs = require('fs');
+var utils = require('/usr/vm/node_modules/utils');
+var VM = require('/usr/vm/node_modules/VM');
+var vmtest = require('../common/vmtest.js');
+
+// this puts test stuff in global, so we need to tell jsl about that:
+/* jsl:import ../node_modules/nodeunit-plus/index.js */
+require('nodeunit-plus');
+
+VM.loglevel = 'DEBUG';
+
+var image_uuid = vmtest.CURRENT_SMARTOS_UUID;
+var trim = utils.trim;
+
+test('test create vm with snapshot limits, disabled by NULL', function (t) {
+    var payload = {
+        alias: 'test-zfs-limits-null-' + process.pid,
+        autoboot: true,
+        brand: 'joyent-minimal',
+        delegate_dataset: true,
+        do_not_inventory: true,
+        max_locked_memory: 512,
+        max_physical_memory: 512,
+        max_swap: 1024,
+        zfs_filesystem_limit: 10,
+        zfs_snapshot_limit: 11
+    };
+    var state = {brand: payload.brand};
+
+    vmtest.on_new_vm(t, image_uuid, payload, state, [
+        function (cb) {
+            // Sanity check VM metadata
+            VM.load(state.uuid, function (err, obj) {
+                t.ok(!err, 'load obj for new VM');
+                if (err) {
+                    cb(err);
+                    return;
+                }
+                t.equal(obj.zfs_filesystem_limit, 10, 'zfs_filesystem_limit');
+                t.equal(obj.zfs_snapshot_limit, 11, 'zfs_snapshot_limit');
+                cb();
+            });
+        }, function (cb) {
+            VM.update(state.uuid, {
+		// Extra run of the normal limits test, checking that
+		// null is now an acceptable synonym for "remove the limit".
+                zfs_filesystem_limit: null,
+                zfs_snapshot_limit: undefined
+            }, function (e) {
+                t.ok(!e, 'updated VM: ' + (e ? e.message : 'success'));
+                cb(e);
+            });
+        }, function (cb) {
+            // check again, should be gone now
+            VM.load(state.uuid, function (err, obj) {
+                t.ok(!err, 'load obj for new VM');
+                if (err) {
+                    cb(err);
+                    return;
+                }
+                t.equal(obj.zfs_filesystem_limit, undefined, 'zfs_filesystem_limit');
+                t.equal(obj.zfs_snapshot_limit, undefined, 'zfs_snapshot_limit');
+                cb();
+            });
+        }
+    ]);
+});

--- a/src/vm/tests/test-zfs-limits-null.js
+++ b/src/vm/tests/test-zfs-limits-null.js
@@ -16,7 +16,7 @@ VM.loglevel = 'DEBUG';
 var image_uuid = vmtest.CURRENT_SMARTOS_UUID;
 var trim = utils.trim;
 
-test('test create vm with snapshot limits, disabled by NULL', function (t) {
+test('test create vm with snapshot limits, disabled by null', function (t) {
     var payload = {
         alias: 'test-zfs-limits-null-' + process.pid,
         autoboot: true,


### PR DESCRIPTION
…mpty-string.