### PR TITLE
OS-8198 Allow bootable-off-ZFS-pool ("standalone") SmartOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 /src/node-kstat/build
 /src/nomknod.so.32
 /src/nomknod.so.64
+/src/piadm
 /src/removable_disk
 /src/smartdc/bin/qemu-exec
 /src/sysevent

--- a/man/Makefile
+++ b/man/Makefile
@@ -28,6 +28,7 @@ MAN_FILES = \
 	usr/share/man/man1m/imgadm.1m \
 	usr/share/man/man1m/mkzpool.1m \
 	usr/share/man/man1m/nictagadm.1m \
+	usr/share/man/man1m/piadm.1m \
 	usr/share/man/man1m/sysevent.1m \
 	usr/share/man/man1m/sysinfo.1m \
 	usr/share/man/man1m/vmadm.1m \

--- a/man/manifest
+++ b/man/manifest
@@ -15,6 +15,7 @@ f usr/share/man/man1m/fwadm.1m 0444 root bin
 f usr/share/man/man1m/imgadm.1m 0444 root bin
 f usr/share/man/man1m/mkzpool.1m 0444 root bin
 f usr/share/man/man1m/nictagadm.1m 0444 root bin
+f usr/share/man/man1m/piadm.1m 0444 root bin
 f usr/share/man/man1m/sysevent.1m 0444 root bin
 f usr/share/man/man1m/sysinfo.1m 0444 root bin
 f usr/share/man/man1m/vmadm.1m 0444 root bin

--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -241,8 +241,8 @@ The following exit values are returned:
          An error occurred, but no change was made
 
      2
-	 A fatal error occurred, and there may be partial change or
-	 other residual files or directories.
+         A fatal error occurred, and there may be partial change or
+         other residual files or directories.
 
      3
          A corrupt environment on what is supposed to be a bootable pool.
@@ -273,3 +273,7 @@ The following exit values are returned:
     UEFI.  A hand-partitioned GPT disk may be able to be bootable with both
     BIOS and UEFI, and can have some of its other GPT parititions used for
     other purposes.
+
+    If a bootable pool's boot image or platform image becomes corrupt, even
+    if it's `zones`, a machine can still be booted with a USB stick, CD-ROM,
+    or other method of booting SmartOS, and recovery methods can occur.

--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -73,13 +73,13 @@ piadm(1M) -- Manage SmartOS Platform Images
 	other can also be bootable from UEFI systems.  The `bootable`
 	subcommand will indicate this.
 
-      install <PI-stamp, PI-tarball, PI-tarball-URL> [ZFS-pool-name]
+      install <PI-stamp, PI-tarball, PI-tarball-URL, "latest"> [ZFS-pool-name]
 
         Installs a new Platform Image into the bootable pool.  If there are
         more than one bootable pools, a pool name will be required.
         piadm(1M) requires a Platform Image gzipped tar file.  If a PI-stamp
-        is supplied, the well-known public SmartOS PI repository will be
-        queried with the specified PI-stamp.
+        or the word "latest" is supplied, the well-known public SmartOS PI
+        repository will be queried with the specified PI-stamp.
 
       list [ZFS-pool-name]
 
@@ -104,9 +104,6 @@ The following exit values are returned:
 
      1
          An error occurred.
-
-     2
-         Invalid Platform Image
 
 
 ## SEE ALSO

--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -5,8 +5,7 @@ piadm(1M) -- Manage SmartOS Platform Images
 ## SYNOPSIS
     /usr/sbin/piadm [-v | -vv] <command> [command-specific arguments]
 
-    piadm activate <PI-stamp> [ZFS-pool-name]
-    piadm assign <PI-stamp> [ZFS-pool-name]
+    piadm activate|assign <PI-stamp> [ZFS-pool-name]
     piadm bootable
     piadm bootable [-dr] <ZFS-pool-name>
     piadm bootable -e [ -i <source> ] <ZFS-pool-name>

--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -2,7 +2,7 @@ piadm(1M) -- Manage SmartOS Platform Images
 ===========================================
 
 ## SYNOPSIS
-    /usr/sbin/piadm [-v] <command> [command-specific arguments]
+    /usr/sbin/piadm [-v | -vv] <command> [command-specific arguments]
 
 ## DESCRIPTION
 
@@ -101,7 +101,11 @@ drwxr-xr-x   4 root     root           5 Jul 15 04:12 platform-20200714T195617Z
 
 ## COMMANDS
 
-    The following commands and options are supported:
+    The piadm(1M) command will produce more verbose output if run with -v, or
+    with -vv will produce both -v output and enable the shell's -x flag,
+    which produces output of all of the commands run in the piadm(1M) script.
+
+    piadm(1M) commands and options are:
 
       activate <PI-stamp> [ZFS-pool-name]
       assign <PI-stamp> [ZFS-pool-name]
@@ -234,7 +238,14 @@ The following exit values are returned:
          Successful completion.
 
      1
-         An error occurred.
+         An error occurred, but no change was made
+
+     2
+	 A fatal error occurred, and there may be partial change or
+	 other residual files or directories.
+
+     3
+         A corrupt environment on what is supposed to be a bootable pool.
 
 
 ## SEE ALSO

--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -255,9 +255,21 @@ The following exit values are returned:
 ## NOTES
 
     Many ZFS pool types are not allowed to be bootable.  The system's BIOS or
-    EFI must locate a bootable disk on a bootable pool in order to boot.
+    UEFI must locate a bootable disk on a bootable pool in order to boot.
+    Future work in illumos will enable more ZFS pool types to be bootable,
+    but for now a ZFS pool should be a single-level-vdev pool, namely one of:
+
+      - Single disk
+      - Mirror
+      - RaidZ (any parity)
 
     SmartOS still loads a ramdisk root with a read-only /usr filesystem, even
-    with a bootable pool.
+    when booted from a bootable pool.  This means a bootable pool that isn't
+    the SmartOS `zones` pool receives relatively few writes unless it it used
+    for some other purpose as well.
 
-    <Notes of ZFS pools>
+    A bootable pool created without the -B option, but using whole disks,
+    will be BIOS bootable thanks to space for the MBR, but not bootable with
+    UEFI.  A hand-partitioned GPT disk may be able to be bootable with both
+    BIOS and UEFI, and can have some of its other GPT parititions used for
+    other purposes.

--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -187,7 +187,7 @@ drwxr-xr-x   4 root     root           5 Jul 15 04:12 platform-20200714T195617Z
 [root@smartos ~]# piadm bootable
 standalone                     ==> non-bootable
 zones                          ==> non-bootable
-[root@smartos ~]# piadm bootable -e -i latest standalone
+[root@smartos ~]# piadm -v bootable -e -i latest standalone
 Installing PI 20200701T231659Z
 Platform Image 20200701T231659Z will be loaded on next boot,
     with a new boot image,
@@ -207,17 +207,15 @@ PI STAMP           BOOTABLE FILESYSTEM            BOOT BITS?   NOW   NEXT
 [root@smartos ~]# piadm list
 PI STAMP           BOOTABLE FILESYSTEM            BOOT BITS?   NOW   NEXT
 20200714T195617Z   standalone/boot                next         yes   yes
-[root@smartos ~]# piadm install https://example.com/PIs/platform-20200715T192200Z.tgz
+[root@smartos ~]# piadm -v install https://example.com/PIs/platform-20200715T192200Z.tgz
 Installing https://example.com/PIs/platform-20200715T192200Z.tgz
         (downloaded to /tmp/tmp.Bba0Ac)
 Installing PI 20200715T192200Z
-umount: warning: /tmp/tmp.XbaqBc/mnt not in mnttab
-umount: /tmp/tmp.XbaqBc/mnt not mounted
 [root@smartos ~]# piadm list
 PI STAMP           BOOTABLE FILESYSTEM            BOOT BITS?   NOW   NEXT
 20200714T195617Z   standalone/boot                next         yes   yes
 20200715T192200Z   standalone/boot                none         no    no
-[root@smartos ~]# piadm activate 20200715T192200Z
+[root@smartos ~]# piadm -v activate 20200715T192200Z
 Platform Image 20200715T192200Z will be loaded on next boot,
     WARNING:  20200715T192200Z has no matching boot image, using
     boot image  20200714T195617Z

--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -1,0 +1,124 @@
+piadm(1M) -- Manage SmartOS Platform Images
+===========================================
+
+## SYNOPSIS
+    /usr/sbin/piadm [-v] <command> [command-specific arguments]
+
+## DESCRIPTION
+
+    Historically, SmartOS booted off of a USB key or a read-only media like
+    CD-ROM.  The copy and version of the SmartOS software on one of these
+    media is called a Platform Image.  A Platform Image is described in
+    detail in the next section. 
+
+    piadm(1M) manages multiple copies of Platform Images on a bootable ZFS
+    pool, allowing easier updates to Platform Images and maintaining multiple
+    Platform Images on a single boot media.  The method and implementation of
+    SmartOS booting does not change vs. a USB key or CD-ROM, but merely uses
+    a bootable ZFS pool as the source of the Platform Image, which can be the
+    SmartOS `zones` pool if it is a bootable pool.
+
+## PLATFORM IMAGES
+
+    A SmartOS Platform Image (PI) is identified by creation timestamp,
+    referred to here as a PI-stamp.  One can see it in uname(1M):
+
+        smartos-build(~)[0]% uname -a
+	SunOS smartos-build 5.11 joyent_20200602T173751Z i86pc i386 i86pc
+	smartos-build(~)[0]% 
+
+    The PI-stamp for this system's Platform Image is `20200602T173751Z`.
+
+    The Platform Image is a directory containing:
+
+        - A directory structure in a format used by loader(5).
+
+        - The SmartOS `unix` kernel
+
+	- The SmartOS boot archive containing kernel modules, libraries,
+	  commands, and more.
+
+        - A manifest and hash.
+
+	- A file containing the PI-stamp.
+
+    The SmartOS loader(5) will find a path to a Platform Image on the
+    bootable ZFS pool, and will load `unix` and then the boot archive.
+
+    Platform images are supplies by a gzipped tarball containing the above.
+
+## COMMANDS
+
+    The following commands and options are supported:
+
+      activate <PI-stamp> [ZFS-pool-name]
+      assign <PI-stamp> [ZFS-pool-name]
+
+        Activate a Platform Image for the next boot, on a specified ZFS pool
+        if there are more than one bootable pools imported.  It is up to the
+        administrator to know which pool the system will actually boot.
+
+        `activate` and `assign` are synonyms, for those used to other
+        distros' `beadm`, or Triton's `sdcadm platform`, respectively.
+
+      bootable [-d] [-e] [ZFS-pool-name]
+
+        Query or upgrade a ZFS pool's bootable status.  With no arguments,
+        the status of all imported pools will be queried.  -d will disable a
+        pool from being bootable, and -e will enable one.  As mentioned
+        earlier, it is up to the administrator to know which pool the system
+        will actually boot.
+
+	Some pools can only be bootable from an older BIOS system, while
+	other can also be bootable from UEFI systems.  The `bootable`
+	subcommand will indicate this.
+
+      install <PI-stamp, PI-tarball, PI-tarball-URL> [ZFS-pool-name]
+
+        Installs a new Platform Image into the bootable pool.  If there are
+        more than one bootable pools, a pool name will be required.
+        piadm(1M) requires a Platform Image gzipped tar file.  If a PI-stamp
+        is supplied, the well-known public SmartOS PI repository will be
+        queried with the specified PI-stamp.
+
+      list [ZFS-pool-name]
+
+        Lists the available platform images on bootable pools.
+
+      remove <PI-stamp> [ZFS-pool-name]
+
+        The opposite of `install`, and only accepts a PI-stamp.
+
+
+
+## EXAMPLES
+
+
+
+## EXIT STATUS
+
+The following exit values are returned:
+
+     0
+         Successful completion.
+
+     1
+         An error occurred.
+
+     2
+         Invalid Platform Image
+
+
+## SEE ALSO
+
+    zpool(1M), loader(5)
+
+## NOTES
+
+    Many ZFS pool types are not allowed to be bootable.  The system's BIOS or
+    EFI must locate a bootable disk on a bootable pool in order to boot.
+
+    SmartOS still loads a ramdisk root with a read-only /usr filesystem, even
+    with a bootable pool.
+
+    <Notes of ZFS pools>

--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -25,7 +25,7 @@ piadm(1M) -- Manage SmartOS Platform Images
 
         smartos-build(~)[0]% uname -a
         SunOS smartos-build 5.11 joyent_20200602T173751Z i86pc i386 i86pc
-        smartos-build(~)[0]% 
+        smartos-build(~)[0]%
 
     The PI-stamp for this system's Platform Image is `20200602T173751Z`.
 
@@ -85,10 +85,10 @@ piadm(1M) -- Manage SmartOS Platform Images
 ```
 [root@smartos ~]# piadm bootable
 standalone                     ==> BIOS and UEFI
-zones                          ==> non-bootable 
+zones                          ==> non-bootable
 [root@smartos ~]# piadm list
-PI STAMP           BOOTABLE FILESYSTEM            BOOT BITS?   NOW   NEXT  
-20200714T195617Z   standalone/boot                next         yes   yes  
+PI STAMP           BOOTABLE FILESYSTEM            BOOT BITS?   NOW   NEXT
+20200714T195617Z   standalone/boot                next         yes   yes
 [root@smartos ~]# ls -l /standalone/boot
 total 7
 lrwxrwxrwx   1 root     root          23 Jul 15 04:22 boot -> ./boot-20200714T195617Z
@@ -96,7 +96,7 @@ drwxr-xr-x   4 root     root          15 Jul 15 04:12 boot-20200714T195617Z
 drwxr-xr-x   3 root     root           3 Jul 15 04:22 etc
 lrwxrwxrwx   1 root     root          27 Jul 15 04:22 platform -> ./platform-20200714T195617Z
 drwxr-xr-x   4 root     root           5 Jul 15 04:12 platform-20200714T195617Z
-[root@smartos ~]# 
+[root@smartos ~]#
 ```
 
 ## COMMANDS
@@ -181,8 +181,8 @@ drwxr-xr-x   4 root     root           5 Jul 15 04:12 platform-20200714T195617Z
 ```
 [root@smartos ~]# zpool create -f -B standalone c1t1d0
 [root@smartos ~]# piadm bootable
-standalone                     ==> non-bootable 
-zones                          ==> non-bootable 
+standalone                     ==> non-bootable
+zones                          ==> non-bootable
 [root@smartos ~]# piadm bootable -e -i latest standalone
 Installing PI 20200701T231659Z
 Platform Image 20200701T231659Z will be loaded on next boot,
@@ -190,19 +190,19 @@ Platform Image 20200701T231659Z will be loaded on next boot,
     boot image  20200701T231659Z
 [root@smartos ~]# piadm bootable
 standalone                     ==> BIOS and UEFI
-zones                          ==> non-bootable 
+zones                          ==> non-bootable
 [root@smartos ~]# piadm list
-PI STAMP           BOOTABLE FILESYSTEM            BOOT BITS?   NOW   NEXT  
-20200701T231659Z   standalone/boot                next         no    yes  
-[root@smartos ~]# 
+PI STAMP           BOOTABLE FILESYSTEM            BOOT BITS?   NOW   NEXT
+20200701T231659Z   standalone/boot                next         no    yes
+[root@smartos ~]#
 ```
 
 ### Installing a PI-only (use old boot bits) update and activating it
 
 ```
 [root@smartos ~]# piadm list
-PI STAMP           BOOTABLE FILESYSTEM            BOOT BITS?   NOW   NEXT  
-20200714T195617Z   standalone/boot                next         yes   yes  
+PI STAMP           BOOTABLE FILESYSTEM            BOOT BITS?   NOW   NEXT
+20200714T195617Z   standalone/boot                next         yes   yes
 [root@smartos ~]# piadm install https://example.com/PIs/platform-20200715T192200Z.tgz
 Installing https://example.com/PIs/platform-20200715T192200Z.tgz
         (downloaded to /tmp/tmp.Bba0Ac)
@@ -210,18 +210,18 @@ Installing PI 20200715T192200Z
 umount: warning: /tmp/tmp.XbaqBc/mnt not in mnttab
 umount: /tmp/tmp.XbaqBc/mnt not mounted
 [root@smartos ~]# piadm list
-PI STAMP           BOOTABLE FILESYSTEM            BOOT BITS?   NOW   NEXT  
-20200714T195617Z   standalone/boot                next         yes   yes  
-20200715T192200Z   standalone/boot                none         no    no   
+PI STAMP           BOOTABLE FILESYSTEM            BOOT BITS?   NOW   NEXT
+20200714T195617Z   standalone/boot                next         yes   yes
+20200715T192200Z   standalone/boot                none         no    no
 [root@smartos ~]# piadm activate 20200715T192200Z
 Platform Image 20200715T192200Z will be loaded on next boot,
     WARNING:  20200715T192200Z has no matching boot image, using
     boot image  20200714T195617Z
 [root@smartos ~]# piadm list
-PI STAMP           BOOTABLE FILESYSTEM            BOOT BITS?   NOW   NEXT  
-20200714T195617Z   standalone/boot                next         yes   no   
-20200715T192200Z   standalone/boot                none         no    yes  
-[root@smartos ~]# 
+PI STAMP           BOOTABLE FILESYSTEM            BOOT BITS?   NOW   NEXT
+20200714T195617Z   standalone/boot                next         yes   no
+20200715T192200Z   standalone/boot                none         no    yes
+[root@smartos ~]#
 
 ```
 

--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -115,7 +115,7 @@ drwxr-xr-x   4 root     root           5 Jul 15 04:12 platform-20200714T195617Z
         `activate` and `assign` are synonyms, for those used to other
         distros' `beadm`, or Triton's `sdcadm platform`, respectively.
 
-      bootable [-d|-e [-i <source>]] [ZFS-pool-name]
+      bootable [-d|-e [-i <source>]|-r] [ZFS-pool-name]
 
         Query or upgrade a ZFS pool's bootable status.  With no arguments,
         the status of all imported pools will be queried.  -d will disable a
@@ -125,6 +125,10 @@ drwxr-xr-x   4 root     root           5 Jul 15 04:12 platform-20200714T195617Z
         As mentioned earlier, it is up to the administrator to know which
         pool the system will actually boot. Unlike install, this command will
         always attempt to install a corresponding boot image as well.
+
+	The -r flag will refresh a bootable pool's MBR and/or ESP.  This is
+	especially useful on mirror or raidz pools that have new devices
+	attached.
 
         Some pools can only be bootable from an older BIOS system, while
         other can also be bootable from UEFI systems.  The `bootable`

--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -126,9 +126,9 @@ drwxr-xr-x   4 root     root           5 Jul 15 04:12 platform-20200714T195617Z
         pool the system will actually boot. Unlike install, this command will
         always attempt to install a corresponding boot image as well.
 
-	The -r flag will refresh a bootable pool's MBR and/or ESP.  This is
-	especially useful on mirror or raidz pools that have new devices
-	attached.
+        The -r flag will refresh a bootable pool's MBR and/or ESP.  This is
+        especially useful on mirror or raidz pools that have new devices
+        attached.
 
         Some pools can only be bootable from an older BIOS system, while
         other can also be bootable from UEFI systems.  The `bootable`

--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -274,4 +274,5 @@ The following exit values are returned:
 
     If a bootable pool's boot image or platform image becomes corrupt, even
     if it's `zones`, a machine can still be booted with a USB stick, CD-ROM,
-    or other method of booting SmartOS, and recovery methods can occur.
+    or other method of booting SmartOS.  A bootable pool can then be
+    repaired using piadm(1M) from the USB stick or CD-ROM.

--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -61,7 +61,7 @@ piadm(1M) -- Manage SmartOS Platform Images
         `activate` and `assign` are synonyms, for those used to other
         distros' `beadm`, or Triton's `sdcadm platform`, respectively.
 
-      bootable [-d] [-e] [ZFS-pool-name]
+      bootable [-d|-e] [ZFS-pool-name]
 
         Query or upgrade a ZFS pool's bootable status.  With no arguments,
         the status of all imported pools will be queried.  -d will disable a

--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -1,15 +1,26 @@
 piadm(1M) -- Manage SmartOS Platform Images
 ===========================================
 
+
 ## SYNOPSIS
     /usr/sbin/piadm [-v | -vv] <command> [command-specific arguments]
+
+    piadm activate <PI-stamp> [ZFS-pool-name]
+    piadm assign <PI-stamp> [ZFS-pool-name]
+    piadm bootable
+    piadm bootable [-dr] <ZFS-pool-name>
+    piadm bootable -e [ -i <source> ] <ZFS-pool-name>
+    piadm install <source> [ZFS-pool-name]
+    piadm list [ZFS-pool-name]
+    piadm remove <PI-stamp> [ZFS-pool-name]
 
 ## DESCRIPTION
 
     Historically, SmartOS booted off of a USB key or a read-only media like
     CD-ROM.  The copy and version of the SmartOS software on one of these
     media is called a Platform Image.  A Platform Image is described in
-    detail in the next section.
+    detail in the next section.  The piadm(1M) utility enables and manages
+    the ability to instead boot directly off of a ZFS pool.
 
     piadm(1M) manages multiple copies of Platform Images on a bootable ZFS
     pool, allowing easier updates to Platform Images and maintaining multiple
@@ -101,14 +112,15 @@ drwxr-xr-x   4 root     root           5 Jul 15 04:12 platform-20200714T195617Z
 
 ## COMMANDS
 
-    The piadm(1M) command will produce more verbose output if run with -v, or
-    with -vv will produce both -v output and enable the shell's -x flag,
-    which produces output of all of the commands run in the piadm(1M) script.
+    The piadm(1M) command will produce more verbose output if -v is stated
+    prior to the command. If -vv is stated prior to the command, piadm(1M)
+    will produce both -v output and enable the shell's -x flag, which
+    produces output of all of the commands run in the piadm(1M) script.
 
     piadm(1M) commands and options are:
 
-      activate <PI-stamp> [ZFS-pool-name]
-      assign <PI-stamp> [ZFS-pool-name]
+      piadm activate <PI-stamp> [ZFS-pool-name]
+      piadm assign <PI-stamp> [ZFS-pool-name]
 
         Activate a Platform Image for the next boot, on a specified ZFS pool
         if there are more than one bootable pools imported.  It is up to the
@@ -119,7 +131,7 @@ drwxr-xr-x   4 root     root           5 Jul 15 04:12 platform-20200714T195617Z
         `activate` and `assign` are synonyms, for those used to other
         distros' `beadm`, or Triton's `sdcadm platform`, respectively.
 
-      bootable [-d|-e [-i <source>]|-r] [ZFS-pool-name]
+      piadm bootable [-d | -e [-i <source>] | -r] [ZFS-pool-name]
 
         Query or upgrade a ZFS pool's bootable status.  With no arguments,
         the status of all imported pools will be queried.  -d will disable a
@@ -134,11 +146,11 @@ drwxr-xr-x   4 root     root           5 Jul 15 04:12 platform-20200714T195617Z
         especially useful on mirror or raidz pools that have new devices
         attached.
 
-        Some pools can only be bootable from an older BIOS system, while
-        other can also be bootable from UEFI systems.  The `bootable`
-        subcommand will indicate this.
+        Some pools can only be bootable on systems configured to boot in
+        legacy BIOS mode, while others can also be bootable from UEFI
+        systems.  The `bootable` subcommand will indicate this.
 
-      install <source> [ZFS-pool-name]
+      piadm install <source> [ZFS-pool-name]
 
         Installs a new Platform Image into the bootable pool.  If the source
         also contains the boot image (like an ISO does), the Boot Image will
@@ -165,12 +177,12 @@ drwxr-xr-x   4 root     root           5 Jul 15 04:12 platform-20200714T195617Z
 
           - A URL to either one of an ISO image or a gzipped PI tarball.
 
-      list [ZFS-pool-name]
+      piadm list [ZFS-pool-name]
 
         Lists the available platform images (and boot images) on bootable
         pools.
 
-      remove <PI-stamp> [ZFS-pool-name]
+      piadm remove <PI-stamp> [ZFS-pool-name]
 
         The opposite of `install`, and only accepts a PI-stamp.  If a boot
         image exists with the specified PI-stamp, it will also be removed
@@ -263,7 +275,7 @@ The following exit values are returned:
 
     SmartOS still loads a ramdisk root with a read-only /usr filesystem, even
     when booted from a bootable pool.  This means a bootable pool that isn't
-    the SmartOS `zones` pool receives relatively few writes unless it it used
+    the SmartOS `zones` pool receives relatively few writes unless it is used
     for some other purpose as well.
 
     A bootable pool created without the -B option, but using whole disks,

--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -21,8 +21,8 @@ piadm(1M) -- Manage SmartOS Platform Images
     detail in the next section.  The piadm(1M) utility enables and manages
     the ability to instead boot directly off of a ZFS pool.
 
-    piadm(1M) manages multiple copies of Platform Images on a bootable ZFS
-    pool, allowing easier updates to Platform Images and maintaining multiple
+    piadm(1M) manages multiple Platform Images on a bootable ZFS pool,
+    allowing easier updates to Platform Images and maintaining multiple
     Platform Images on a single boot media.  The method and implementation of
     SmartOS booting does not change vs. a USB key or CD-ROM, but merely uses
     a bootable ZFS pool as the source of the Platform Image, which can be the
@@ -88,7 +88,8 @@ piadm(1M) -- Manage SmartOS Platform Images
           Image.
 
         - Symbolic links /POOL/boot/platform and /POOL/boot/boot that point
-          to the on-next-boot Platform Image and Boot Image.
+          to the Platform Image and Boot Image that will be used at the next
+          boot.
 
     For example:
 

--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -193,6 +193,35 @@ PI STAMP           BOOTABLE FILESYSTEM            BOOT BITS?   NOW   NEXT
 [root@smartos ~]# 
 ```
 
+### Installing a PI-only (use old boot bits) update and activating it
+
+```
+[root@smartos ~]# piadm list
+PI STAMP           BOOTABLE FILESYSTEM            BOOT BITS?   NOW   NEXT  
+20200714T195617Z   standalone/boot                next         yes   yes  
+[root@smartos ~]# piadm install https://example.com/PIs/platform-20200715T192200Z.tgz
+Installing https://example.com/PIs/platform-20200715T192200Z.tgz
+        (downloaded to /tmp/tmp.Bba0Ac)
+Installing PI 20200715T192200Z
+umount: warning: /tmp/tmp.XbaqBc/mnt not in mnttab
+umount: /tmp/tmp.XbaqBc/mnt not mounted
+[root@smartos ~]# piadm list
+PI STAMP           BOOTABLE FILESYSTEM            BOOT BITS?   NOW   NEXT  
+20200714T195617Z   standalone/boot                next         yes   yes  
+20200715T192200Z   standalone/boot                none         no    no   
+[root@smartos ~]# piadm activate 20200715T192200Z
+Platform Image 20200715T192200Z will be loaded on next boot,
+    WARNING:  20200715T192200Z has no matching boot image, using
+    boot image  20200714T195617Z
+[root@smartos ~]# piadm list
+PI STAMP           BOOTABLE FILESYSTEM            BOOT BITS?   NOW   NEXT  
+20200714T195617Z   standalone/boot                next         yes   no   
+20200715T192200Z   standalone/boot                none         no    yes  
+[root@smartos ~]# 
+
+```
+
+
 ## EXIT STATUS
 
 The following exit values are returned:

--- a/src/Makefile
+++ b/src/Makefile
@@ -286,6 +286,7 @@ BUILT_TARGETS = \
 	mkzpool \
 	nomknod.so.32 \
 	nomknod.so.64 \
+	piadm \
 	removable_disk \
 	sysevent \
 	sysinfo_mod.so \
@@ -390,7 +391,7 @@ install: all $(SUBDIRS)
 	mkdir -p $(DESTDIR)/usr/bin
 	cp -p $(USRBIN_TARGETS) $(DESTDIR)/usr/bin
 	mkdir -p $(DESTDIR)/usr/sbin
-	cp -p fssstat sysevent zonememstat zonemon $(DESTDIR)/usr/sbin
+	cp -p fssstat piadm sysevent zonememstat zonemon $(DESTDIR)/usr/sbin
 	cp -p $(USR_LIB_TARGETS) $(DESTDIR)/usr/lib
 	mkdir -p $(DESTDIR)/smartdc/bin
 	cp -p $(SMARTDC_TARGETS) $(DESTDIR)/smartdc/bin

--- a/src/lib/sdc/usb-key.sh
+++ b/src/lib/sdc/usb-key.sh
@@ -143,10 +143,9 @@ function mount_ISO
 {
 	local mnt=`extract_mountpath $1`
 
-	# XXX KEBE SAYS JUST TRUST IT FOR NOW...
 	for disk in `disklist -r`; do
 		mount -F hsfs /dev/dsk/${disk}s0 $mnt
-		if [[ $? != 0 ]]; then
+		if [[ $? -ne 0 ]]; then
 			continue
 		fi
 		if [[ -d ${mnt}/boot ]]; then

--- a/src/lib/sdc/usb-key.sh
+++ b/src/lib/sdc/usb-key.sh
@@ -51,10 +51,7 @@ function usb_key_version()
 	echo $(( 0x$loader_major ))
 }
 
-#
-# Mount the usbkey at the standard mount location (or whatever is specified).
-#
-function mount_usb_key()
+function extract_mountpath()
 {
 	local mnt=$1
 
@@ -62,6 +59,16 @@ function mount_usb_key()
 		mnt=/mnt/$(svcprop -p "joyentfs/usb_mountpoint" \
 		    "svc:/system/filesystem/smartdc:default")
 	fi
+
+	echo "$mnt"
+}
+
+#
+# Mount the usbkey at the standard mount location (or whatever is specified).
+#
+function mount_usb_key()
+{
+	local mnt=`extract_mountpath $1`
 
 	if [[ -f "$mnt/.joyliveusb" ]]; then
 		echo $mnt
@@ -114,12 +121,7 @@ function mount_usb_key()
 
 function unmount_usb_key()
 {
-	local mnt=$1
-
-	if [[ -z "$mnt" ]]; then
-		mnt=/mnt/$(svcprop -p "joyentfs/usb_mountpoint" \
-		    "svc:/system/filesystem/smartdc:default")
-	fi
+	local mnt=`extract_mountpath $1`
 
 	typ=$(awk -v "mnt=$mnt" '$2 == mnt { print $3 }' /etc/mnttab)
 
@@ -131,6 +133,45 @@ function unmount_usb_key()
 	fi
 
 	umount "$mnt"
+}
+
+# Evil twins of the {,un}mount_usb_key functions.  These are specific
+# to ISO/hsfs (aka. {C,DV,B}D-ROM) disks.  We may be able to factor-out
+# even more common bits from the usb_key functions, but not today.
+
+function mount_ISO
+{
+	local mnt=`extract_mountpath $1`
+
+	# XXX KEBE SAYS JUST TRUST IT FOR NOW...
+	for disk in `disklist -r`; do
+		mount -F hsfs /dev/dsk/${disk}s0 $mnt
+		if [[ $? != 0 ]]; then
+			continue
+		fi
+		if [[ -d ${mnt}/boot ]]; then
+			return 0
+		fi
+		if ! umount $mnt; then
+			echo "Failed to unmount $mnt">&2
+			return 1
+		fi
+	done
+
+	echo "Couldn't find an ISO" >&2
+	return 1
+}
+
+function unmount_ISO
+{
+	local mnt=`extract_mountpath $1`
+
+	if ! umount $mnt; then
+		echo "Failed to unmount $mnt" >&2
+		return 1
+	fi
+
+	return 0
 }
 
 # replace a loader conf value

--- a/src/lib/sdc/usb-key.sh
+++ b/src/lib/sdc/usb-key.sh
@@ -141,9 +141,10 @@ function unmount_usb_key()
 
 function mount_ISO
 {
-	local mnt=`extract_mountpath $1`
+	local mnt=$(extract_mountpath "$1")
 
-	for disk in `disklist -r`; do
+	mapfile -t disks < <(disklist -r)
+	for a in "${disks[@]}"; do
 		mount -F hsfs /dev/dsk/${disk}s0 $mnt
 		if [[ $? -ne 0 ]]; then
 			continue

--- a/src/lib/sdc/usb-key.sh
+++ b/src/lib/sdc/usb-key.sh
@@ -68,7 +68,7 @@ function extract_mountpath()
 #
 function mount_usb_key()
 {
-	local mnt=`extract_mountpath $1`
+	local mnt=$(extract_mountpath $1)
 
 	if [[ -f "$mnt/.joyliveusb" ]]; then
 		echo $mnt
@@ -121,7 +121,7 @@ function mount_usb_key()
 
 function unmount_usb_key()
 {
-	local mnt=`extract_mountpath $1`
+	local mnt=$(extract_mountpath $1)
 
 	typ=$(awk -v "mnt=$mnt" '$2 == mnt { print $3 }' /etc/mnttab)
 
@@ -164,7 +164,7 @@ function mount_ISO
 
 function unmount_ISO
 {
-	local mnt=`extract_mountpath $1`
+	local mnt=$(extract_mountpath $1)
 
 	if ! umount $mnt; then
 		echo "Failed to unmount $mnt" >&2

--- a/src/lib/sdc/usb-key.sh
+++ b/src/lib/sdc/usb-key.sh
@@ -144,7 +144,7 @@ function mount_ISO
 	local mnt=$(extract_mountpath "$1")
 
 	mapfile -t disks < <(disklist -r)
-	for a in "${disks[@]}"; do
+	for disk in "${disks[@]}"; do
 		mount -F hsfs /dev/dsk/${disk}s0 $mnt
 		if [[ $? -ne 0 ]]; then
 			continue

--- a/src/lib/sdc/usb-key.sh
+++ b/src/lib/sdc/usb-key.sh
@@ -104,7 +104,7 @@ function mount_usb_key()
 			continue
 		fi
 
-		if [[ -f $mnt/.joyliveusb ]]; then
+		if [[ -f $mnt/.joyliveusb || "$2" == "skip" ]]; then
 			echo $mnt
 			return 0
 		fi

--- a/src/manifest
+++ b/src/manifest
@@ -1114,6 +1114,7 @@ d usr/lib/sdc 0755 root bin
 f usr/lib/sdc/net-boot-config 0555 root bin
 s usr/sbin/fwadm=../fw/sbin/fwadm
 f usr/sbin/fssstat 0555 root bin
+f usr/sbin/piadm 0555 root bin
 f usr/sbin/sysevent 0555 root bin
 s usr/sbin/vmadm=../vm/sbin/vmadm
 s usr/sbin/vminfo=../vm/sbin/vminfo

--- a/src/mkzpool.js
+++ b/src/mkzpool.js
@@ -18,7 +18,7 @@ fatal(msg)
 function
 usage()
 {
-	console.log('usage: ' + process.argv[0] + '[-f] <pool> <file.json>');
+	console.log('usage: ' + process.argv[0] + '[-Bef] <pool> <file.json>');
 	process.exit(-1);
 }
 
@@ -27,12 +27,16 @@ var config;
 var pool;
 
 var option;
+var opt_B = false;
 var opt_e = false;
 var opt_f = false;
-var parser = new getopt.BasicParser('ef', process.argv);
+var parser = new getopt.BasicParser('Bef', process.argv);
 
 while ((option = parser.getopt()) !== undefined && !option.error) {
     switch (option.option) {
+	case 'B':
+		opt_B = true;
+		break;
 	case 'e':
 		opt_e = true;
 		break;
@@ -55,7 +59,7 @@ pool = process.argv[parser.optind()];
 json = fs.readFileSync(process.argv[parser.optind() + 1], 'utf8');
 config = JSON.parse(json);
 
-zfs.zpool.create(pool, config, opt_f, opt_e, function (err) {
+zfs.zpool.create(pool, config, opt_f, opt_e, opt_B, function (err) {
 	if (err) {
 		fatal('pool creation failed: ' + err);
 	}

--- a/src/node_modules/zfs.js
+++ b/src/node_modules/zfs.js
@@ -125,20 +125,24 @@ zpool.status = function (pool, callback) {
  * zpool create command, including log devices, cache devices, and hot spares.
  * The input is an object of the form produced by the disklayout library.
  */
-zpool.create = function (pool, config, force, encrypt, callback) {
+zpool.create = function (pool, config, force, encrypt, efi, callback) {
 	var cmd;
 	var args;
 
-	if (arguments.length === 3) {
+    if (arguments.length === 3) {
         callback = force;
         encrypt = false;
         force = false;
+        efi = true;
     } else if (arguments.length === 4) {
         callback = encrypt;
         encrypt = false;
-	} else if (arguments.length !== 5) {
-		throw Error('Invalid arguments, 3, 4, or 5 arguments required');
-	}
+        efi = true;
+    } else if (arguments.length === 5) {
+        efi = true;
+    } else if (arguments.length !== 6) {
+		throw Error('Invalid arguments, 3-6 arguments required');
+    }
 
     if (encrypt === true) {
         cmd = exports.paths.kbmadm;
@@ -148,9 +152,12 @@ zpool.create = function (pool, config, force, encrypt, callback) {
         args = [ 'create' ];
     }
 
+    if (efi === true) {
+	args.push('-B');
+    }
     if (force === true) {
         args.push('-f');
-	}
+    }
 
     args.push(pool);
 

--- a/src/node_modules/zfs.js
+++ b/src/node_modules/zfs.js
@@ -23,99 +23,99 @@ var zpool = exports.zpool = function () { };
 var timeoutDuration = exports.timeoutDuration = 10 * 60 * 1000;
 
 function zfsErrorStr(error, stderr) {
-	if (!error)
-		return (null);
+        if (!error)
+                return (null);
 
-	if (error.killed)
-		return ('Process killed due to timeout.');
+        if (error.killed)
+                return ('Process killed due to timeout.');
 
-	return (error.message || (stderr ? stderr.toString() : ''));
+        return (error.message || (stderr ? stderr.toString() : ''));
 }
 
 function zfsError(error, stderr) {
-	return (new Error(zfsErrorStr(error, stderr)));
+        return (new Error(zfsErrorStr(error, stderr)));
 }
 
 zpool.listFields_ = [ 'name', 'size', 'allocated', 'free', 'cap',
     'health', 'altroot' ];
 
 zpool.listDisks = function () {
-	if (arguments.length !== 1)
-		throw Error('Invalid arguments');
-	var callback = arguments[0];
+        if (arguments.length !== 1)
+                throw Error('Invalid arguments');
+        var callback = arguments[0];
 
-	execFile('/usr/bin/diskinfo', [ '-Hp' ], { timeout: timeoutDuration },
-	    function (error, stdout, stderr) {
-		if (error)
-			return (callback(stderr.toString()));
+        execFile('/usr/bin/diskinfo', [ '-Hp' ], { timeout: timeoutDuration },
+            function (error, stdout, stderr) {
+                if (error)
+                        return (callback(stderr.toString()));
 
-		var disks = [];
-		var rows = parseTabSeperatedTable(stdout);
+                var disks = [];
+                var rows = parseTabSeperatedTable(stdout);
 
-		for (var ii = 0; ii < rows.length; ii++) {
-			disks.push({
-			    type: rows[ii][0],
-			    name: rows[ii][1],
-			    vid: rows[ii][2],
-			    pid: rows[ii][3],
-			    size: rows[ii][4],
-			    removable: (rows[ii][5] === 'yes'),
-			    solid_state: (rows[ii][6] === 'yes')
-			});
-		}
+                for (var ii = 0; ii < rows.length; ii++) {
+                        disks.push({
+                            type: rows[ii][0],
+                            name: rows[ii][1],
+                            vid: rows[ii][2],
+                            pid: rows[ii][3],
+                            size: rows[ii][4],
+                            removable: (rows[ii][5] === 'yes'),
+                            solid_state: (rows[ii][6] === 'yes')
+                        });
+                }
 
-		return (callback(null, disks));
-	});
+                return (callback(null, disks));
+        });
 };
 
 zpool.list = function () {
-	var pool, callback;
-	switch (arguments.length) {
-		case 1:
-			callback = arguments[0];
-			break;
-		case 2:
-			pool     = arguments[0];
-			callback = arguments[1];
-			break;
-		default:
-			throw Error('Invalid arguments');
-	}
-	var args = ['list', '-H', '-o', zpool.listFields_.join(',')];
-	if (pool)
-		args.push(pool);
+        var pool, callback;
+        switch (arguments.length) {
+                case 1:
+                        callback = arguments[0];
+                        break;
+                case 2:
+                        pool     = arguments[0];
+                        callback = arguments[1];
+                        break;
+                default:
+                        throw Error('Invalid arguments');
+        }
+        var args = ['list', '-H', '-o', zpool.listFields_.join(',')];
+        if (pool)
+                args.push(pool);
 
-	execFile(exports.paths.zpool, args, { timeout: timeoutDuration },
-	    function (error, stdout, stderr) {
-		if (error)
-			return (callback(zfsError(error, stderr)));
-		var rows = parseTabSeperatedTable(stdout);
-		return (callback(null, zpool.listFields_, rows));
-	});
+        execFile(exports.paths.zpool, args, { timeout: timeoutDuration },
+            function (error, stdout, stderr) {
+                if (error)
+                        return (callback(zfsError(error, stderr)));
+                var rows = parseTabSeperatedTable(stdout);
+                return (callback(null, zpool.listFields_, rows));
+        });
 };
 
 zpool.status = function (pool, callback) {
-	if (arguments.length != 2)
-		throw Error('Invalid arguments');
+        if (arguments.length != 2)
+                throw Error('Invalid arguments');
 
-	execFile(exports.paths.zpool, [ 'status', pool ],
-	    { timeout: timeoutDuration },
-	    function (error, stdout, stderr) {
-		stdout = stdout.trim();
-		if (error || stdout == 'no pools available\n') {
-			callback(null, 'UNKNOWN');
-			return;
-		}
+        execFile(exports.paths.zpool, [ 'status', pool ],
+            { timeout: timeoutDuration },
+            function (error, stdout, stderr) {
+                stdout = stdout.trim();
+                if (error || stdout == 'no pools available\n') {
+                        callback(null, 'UNKNOWN');
+                        return;
+                }
 
-		var lines = stdout.split('\n');
-		for (var i = 0; i < lines.length; i++) {
-			if (lines[i].trim().substr(0, 5) === 'state') {
-				return (callback(null,
-				    lines[i].trim().substr(7)));
-			}
-		}
-		callback(null, 'UNKNOWN');
-	});
+                var lines = stdout.split('\n');
+                for (var i = 0; i < lines.length; i++) {
+                        if (lines[i].trim().substr(0, 5) === 'state') {
+                                return (callback(null,
+                                    lines[i].trim().substr(7)));
+                        }
+                }
+                callback(null, 'UNKNOWN');
+        });
 };
 
 /*
@@ -126,8 +126,8 @@ zpool.status = function (pool, callback) {
  * The input is an object of the form produced by the disklayout library.
  */
 zpool.create = function (pool, config, force, encrypt, efi, callback) {
-	var cmd;
-	var args;
+        var cmd;
+        var args;
 
     if (arguments.length === 3) {
         callback = force;
@@ -141,7 +141,7 @@ zpool.create = function (pool, config, force, encrypt, efi, callback) {
     } else if (arguments.length === 5) {
         efi = true;
     } else if (arguments.length !== 6) {
-		throw Error('Invalid arguments, 3-6 arguments required');
+                throw Error('Invalid arguments, 3-6 arguments required');
     }
 
     if (encrypt === true) {
@@ -153,7 +153,7 @@ zpool.create = function (pool, config, force, encrypt, efi, callback) {
     }
 
     if (efi === true) {
-	args.push('-B');
+        args.push('-B');
     }
     if (force === true) {
         args.push('-f');
@@ -161,94 +161,94 @@ zpool.create = function (pool, config, force, encrypt, efi, callback) {
 
     args.push(pool);
 
-	config.vdevs.forEach(function (vdev) {
-		if (vdev.type)
-			args.push(vdev.type);
-		if (vdev.devices) {
-			vdev.devices.forEach(function (dev) {
-				args.push(dev.name);
-			});
-		} else {
-			args.push(vdev.name);
-		}
-	});
+        config.vdevs.forEach(function (vdev) {
+                if (vdev.type)
+                        args.push(vdev.type);
+                if (vdev.devices) {
+                        vdev.devices.forEach(function (dev) {
+                                args.push(dev.name);
+                        });
+                } else {
+                        args.push(vdev.name);
+                }
+        });
 
-	if (config.spares) {
-		args.push('spare');
-		config.spares.forEach(function (dev) {
-			args.push(dev.name);
-		});
-	}
+        if (config.spares) {
+                args.push('spare');
+                config.spares.forEach(function (dev) {
+                        args.push(dev.name);
+                });
+        }
 
-	if (config.logs) {
-		args.push('log');
-		config.logs.forEach(function (dev) {
-			args.push(dev.name);
-		});
-	}
+        if (config.logs) {
+                args.push('log');
+                config.logs.forEach(function (dev) {
+                        args.push(dev.name);
+                });
+        }
 
-	if (config.cache) {
-		args.push('cache');
-		config.cache.forEach(function (dev) {
-			args.push(dev.name);
-		});
-	}
+        if (config.cache) {
+                args.push('cache');
+                config.cache.forEach(function (dev) {
+                        args.push(dev.name);
+                });
+        }
 
-	execFile(cmd, args, { timeout: timeoutDuration },
-	    function (error, stdout, stderr) {
-		if (error)
-			return (callback(stderr.toString()));
-		return (callback(null));
-	});
+        execFile(cmd, args, { timeout: timeoutDuration },
+            function (error, stdout, stderr) {
+                if (error)
+                        return (callback(stderr.toString()));
+                return (callback(null));
+        });
 };
 
 zpool.destroy = function (pool, callback) {
-	if (arguments.length != 2)
-		throw Error('Invalid arguments');
+        if (arguments.length != 2)
+                throw Error('Invalid arguments');
 
-	execFile(exports.paths.zpool, [ 'destroy', pool ],
-	    { timeout: timeoutDuration },
-	    function (error, stdout, stderr) {
-		if (error)
-			return (callback(stderr.toString()));
-		return (callback(null));
-	});
+        execFile(exports.paths.zpool, [ 'destroy', pool ],
+            { timeout: timeoutDuration },
+            function (error, stdout, stderr) {
+                if (error)
+                        return (callback(stderr.toString()));
+                return (callback(null));
+        });
 };
 
 zpool.upgrade = function (pool) {
-	var version = -1,
-	    callback;
-	if (arguments.length === 2) {
-		callback = arguments[1];
-	} else if (arguments.length === 3) {
-		version = arguments[1];
-		callback = arguments[2];
-	} else {
-		throw Error('Invalid arguments');
-	}
+        var version = -1,
+            callback;
+        if (arguments.length === 2) {
+                callback = arguments[1];
+        } else if (arguments.length === 3) {
+                version = arguments[1];
+                callback = arguments[2];
+        } else {
+                throw Error('Invalid arguments');
+        }
 
-	var args = [ 'upgrade' ];
-	if (version !== -1)
-		args.push(' -V ' + version);
-	args.push(pool);
+        var args = [ 'upgrade' ];
+        if (version !== -1)
+                args.push(' -V ' + version);
+        args.push(pool);
 
-	execFile(exports.paths.zpool, args, { timeout: timeoutDuration },
-	    function (error, stdout, stderr) {
-		if (error)
-			return (callback(stderr.toString()));
-		return (callback(null));
-	});
+        execFile(exports.paths.zpool, args, { timeout: timeoutDuration },
+            function (error, stdout, stderr) {
+                if (error)
+                        return (callback(stderr.toString()));
+                return (callback(null));
+        });
 };
 
 function parseTabSeperatedTable(data) {
-	var i, numLines, lines = data.trim().split('\n');
-	var rows = [];
-	for (i = 0, numLines = lines.length; i < numLines; i++) {
-		if (lines[i]) {
-			rows.push(lines[i].split('\t'));
-		}
-	}
-	return (rows);
+        var i, numLines, lines = data.trim().split('\n');
+        var rows = [];
+        for (i = 0, numLines = lines.length; i < numLines; i++) {
+                if (lines[i]) {
+                        rows.push(lines[i].split('\t'));
+                }
+        }
+        return (rows);
 }
 
 /*
@@ -260,132 +260,132 @@ function parseTabSeperatedTable(data) {
  * and those fields are tab-separated.
  */
 function parsePropertyList(data) {
-	var lines = data.trim().split('\n');
-	var properties = {};
-	lines.forEach(function (line) {
-		var fields = line.split('\t');
-		if (!properties[fields[0]])
-			properties[fields[0]] = {};
-		properties[fields[0]][fields[1]] = fields[2];
-	});
+        var lines = data.trim().split('\n');
+        var properties = {};
+        lines.forEach(function (line) {
+                var fields = line.split('\t');
+                if (!properties[fields[0]])
+                        properties[fields[0]] = {};
+                properties[fields[0]][fields[1]] = fields[2];
+        });
 
-	return (properties);
+        return (properties);
 }
 
 var zfs;
 exports.zfs = zfs = function () {};
 
 zfs.create = function (name, callback) {
-	if (arguments.length != 2)
-		throw Error('Invalid arguments');
+        if (arguments.length != 2)
+                throw Error('Invalid arguments');
 
-	execFile(exports.paths.zfs, [ 'create', name ],
-	    { timeout: timeoutDuration },
-	    function (error, stdout, stderr) {
-		if (error)
-			return (callback(zfsError(error, stderr)));
-		return (callback());
-	});
+        execFile(exports.paths.zfs, [ 'create', name ],
+            { timeout: timeoutDuration },
+            function (error, stdout, stderr) {
+                if (error)
+                        return (callback(zfsError(error, stderr)));
+                return (callback());
+        });
 };
 
 zfs.set = function (name, properties, callback) {
-	if (arguments.length != 3)
-		throw Error('Invalid arguments');
+        if (arguments.length != 3)
+                throw Error('Invalid arguments');
 
-	var keys = Object.keys(properties);
+        var keys = Object.keys(properties);
 
-	// loop over and set all the properties using chained callbacks
-	(function () {
-		var next = arguments.callee;
-		if (!keys.length) {
-			callback();
-			return;
-		}
-		var key = keys.pop();
+        // loop over and set all the properties using chained callbacks
+        (function () {
+                var next = arguments.callee;
+                if (!keys.length) {
+                        callback();
+                        return;
+                }
+                var key = keys.pop();
 
-		execFile(exports.paths.zfs,
-		    ['set', key + '=' + properties[key], name ],
-		    { timeout: timeoutDuration },
-		    function (error, stdout, stderr) {
-			if (error)
-				return (callback(zfsError(error, stderr)));
-			return (next()); // loop by calling enclosing function
-		});
-	})();
+                execFile(exports.paths.zfs,
+                    ['set', key + '=' + properties[key], name ],
+                    { timeout: timeoutDuration },
+                    function (error, stdout, stderr) {
+                        if (error)
+                                return (callback(zfsError(error, stderr)));
+                        return (next()); // loop by calling enclosing function
+                });
+        })();
 };
 
 zfs.get = function (name, propNames, parseable, callback) {
-	if (arguments.length != 4)
-		throw Error('Invalid arguments');
+        if (arguments.length != 4)
+                throw Error('Invalid arguments');
 
-	var opts = '-H';
-	if (parseable)
-		opts += 'p';
+        var opts = '-H';
+        if (parseable)
+                opts += 'p';
 
-	var argv = [ 'get', opts, '-o', 'name,property,value',
-	    propNames.join(',')];
-	if (name)
-		argv.push(name);
+        var argv = [ 'get', opts, '-o', 'name,property,value',
+            propNames.join(',')];
+        if (name)
+                argv.push(name);
 
-	execFile(exports.paths.zfs, argv, { timeout: timeoutDuration },
-	    function (error, stdout, stderr) {
-		if (error)
-			return (callback(zfsError(error, stderr)));
+        execFile(exports.paths.zfs, argv, { timeout: timeoutDuration },
+            function (error, stdout, stderr) {
+                if (error)
+                        return (callback(zfsError(error, stderr)));
 
-		return (callback(null, parsePropertyList(stdout)));
-	});
+                return (callback(null, parsePropertyList(stdout)));
+        });
 };
 
 zfs.snapshot = function (name, callback) {
-	if (arguments.length != 2)
-		throw Error('Invalid arguments');
+        if (arguments.length != 2)
+                throw Error('Invalid arguments');
 
-	execFile(exports.paths.zfs, ['snapshot', name],
-	    { timeout: timeoutDuration },
-	    function (error, stdout, stderr) {
-		if (error)
-			return (callback(zfsError(error, stderr)));
-		return (callback());
-	});
+        execFile(exports.paths.zfs, ['snapshot', name],
+            { timeout: timeoutDuration },
+            function (error, stdout, stderr) {
+                if (error)
+                        return (callback(zfsError(error, stderr)));
+                return (callback());
+        });
 };
 
 zfs.clone = function (snapshot, name, callback) {
-	if (arguments.length != 3)
-		throw Error('Invalid arguments');
+        if (arguments.length != 3)
+                throw Error('Invalid arguments');
 
-	execFile(exports.paths.zfs, ['clone', snapshot, name],
-	    { timeout: timeoutDuration },
-	    function (error, stdout, stderr) {
-		if (error)
-			return (callback(zfsError(error, stderr)));
-		return (callback());
-	});
+        execFile(exports.paths.zfs, ['clone', snapshot, name],
+            { timeout: timeoutDuration },
+            function (error, stdout, stderr) {
+                if (error)
+                        return (callback(zfsError(error, stderr)));
+                return (callback());
+        });
 };
 
 zfs.destroy = function (name, callback) {
-	if (arguments.length != 2)
-		throw Error('Invalid arguments');
+        if (arguments.length != 2)
+                throw Error('Invalid arguments');
 
-	execFile(exports.paths.zfs, ['destroy', name],
-	    { timeout: timeoutDuration },
-	    function (error, stdout, stderr) {
-		if (error)
-			return (callback(zfsError(error, stderr)));
-		return (callback());
-	});
+        execFile(exports.paths.zfs, ['destroy', name],
+            { timeout: timeoutDuration },
+            function (error, stdout, stderr) {
+                if (error)
+                        return (callback(zfsError(error, stderr)));
+                return (callback());
+        });
 };
 
 zfs.destroyAll = function (name, callback) {
-	if (arguments.length != 2)
-		throw Error('Invalid arguments');
+        if (arguments.length != 2)
+                throw Error('Invalid arguments');
 
-	execFile(exports.paths.zfs, ['destroy', '-r',  name],
-	    { timeout: timeoutDuration },
-	    function (error, stdout, stderr) {
-		if (error)
-			return (callback(zfsError(error, stderr)));
-		return (callback());
-	});
+        execFile(exports.paths.zfs, ['destroy', '-r',  name],
+            { timeout: timeoutDuration },
+            function (error, stdout, stderr) {
+                if (error)
+                        return (callback(zfsError(error, stderr)));
+                return (callback());
+        });
 };
 
 /*
@@ -413,158 +413,158 @@ zfs.listFields_ = [ 'name', 'used', 'avail', 'refer', 'type', 'mountpoint' ];
  */
 
 zfs.list = function () {
-	var dataset, callback,
-	    options = {};
-	switch (arguments.length) {
-		case 1:
-			callback = arguments[0];
-			break;
-		case 2:
-			dataset  = arguments[0];
-			callback = arguments[1];
-			break;
-		case 3:
-			dataset  = arguments[0];
-			options  = arguments[1];
-			callback = arguments[2];
-			break;
-		default:
-			throw Error('Invalid arguments');
-	}
+        var dataset, callback,
+            options = {};
+        switch (arguments.length) {
+                case 1:
+                        callback = arguments[0];
+                        break;
+                case 2:
+                        dataset  = arguments[0];
+                        callback = arguments[1];
+                        break;
+                case 3:
+                        dataset  = arguments[0];
+                        options  = arguments[1];
+                        callback = arguments[2];
+                        break;
+                default:
+                        throw Error('Invalid arguments');
+        }
 
-	options.type      = options.type || 'filesystem';
-	options.recursive = options.recursive || false;
+        options.type      = options.type || 'filesystem';
+        options.recursive = options.recursive || false;
 
-	var args = [ 'list', '-H', '-o', zfs.listFields_.join(','),
-	    '-t', options.type ];
-	if (options.recursive) args.push('-r');
-	if (dataset) args.push(dataset);
+        var args = [ 'list', '-H', '-o', zfs.listFields_.join(','),
+            '-t', options.type ];
+        if (options.recursive) args.push('-r');
+        if (dataset) args.push(dataset);
 
-	execFile(exports.paths.zfs, args, { timeout: timeoutDuration },
-	    function (error, stdout, stderr) {
-		if (error)
-			return (callback(zfsError(error, stderr)));
-		var rows = parseTabSeperatedTable(stdout);
-		return (callback(null, zfs.listFields_, rows));
-	});
+        execFile(exports.paths.zfs, args, { timeout: timeoutDuration },
+            function (error, stdout, stderr) {
+                if (error)
+                        return (callback(zfsError(error, stderr)));
+                var rows = parseTabSeperatedTable(stdout);
+                return (callback(null, zfs.listFields_, rows));
+        });
 };
 
 zfs.send = function (snapshot, filename, callback) {
-	fs.open(filename, 'w', 400, function (error, fd) {
-		if (error)
-			return (callback(error));
-		// set the child to write to STDOUT with `fd`
-		var child = spawn(exports.paths.zfs,
-		    [ 'send', snapshot ], undefined, [ -1, fd ]);
-		child.addListener('exit', function (code) {
-			if (code) {
-				callback(new Error('Return code was ' + code));
-				return;
-			}
-			fs.close(fd, function () {
-				callback();
-			});
-		});
+        fs.open(filename, 'w', 400, function (error, fd) {
+                if (error)
+                        return (callback(error));
+                // set the child to write to STDOUT with `fd`
+                var child = spawn(exports.paths.zfs,
+                    [ 'send', snapshot ], undefined, [ -1, fd ]);
+                child.addListener('exit', function (code) {
+                        if (code) {
+                                callback(new Error('Return code was ' + code));
+                                return;
+                        }
+                        fs.close(fd, function () {
+                                callback();
+                        });
+                });
 
-		return (null);
-	});
+                return (null);
+        });
 };
 
 zfs.receive = function (name, filename, callback) {
-	fs.open(filename, 'r', 400, function (error, fd) {
-		if (error)
-			return (callback(error));
-		// set the child to read from STDIN with `fd`
-		var child = spawn(exports.paths.zfs,
-		    [ 'receive', name ], undefined, [ fd ]);
-		child.addListener('exit', function (code) {
-			if (code) {
-				return (callback(new Error(
-				    'Return code was ' + code)));
-			}
-			fs.close(fd, function () {
-				return (callback());
-			});
+        fs.open(filename, 'r', 400, function (error, fd) {
+                if (error)
+                        return (callback(error));
+                // set the child to read from STDIN with `fd`
+                var child = spawn(exports.paths.zfs,
+                    [ 'receive', name ], undefined, [ fd ]);
+                child.addListener('exit', function (code) {
+                        if (code) {
+                                return (callback(new Error(
+                                    'Return code was ' + code)));
+                        }
+                        fs.close(fd, function () {
+                                return (callback());
+                        });
 
-			return (null);
-		});
+                        return (null);
+                });
 
-		return (null);
-	});
+                return (null);
+        });
 };
 
 zfs.list_snapshots = function () {
-	var snapshot, callback;
-	switch (arguments.length) {
-		case 1:
-			callback = arguments[0];
-			break;
-		case 2:
-			snapshot = arguments[0];
-			callback = arguments[1];
-			break;
-		default:
-			throw Error('Invalid arguments');
-	}
-	var args = ['list', '-H', '-t', 'snapshot'];
-	if (snapshot) args.push(snapshot);
+        var snapshot, callback;
+        switch (arguments.length) {
+                case 1:
+                        callback = arguments[0];
+                        break;
+                case 2:
+                        snapshot = arguments[0];
+                        callback = arguments[1];
+                        break;
+                default:
+                        throw Error('Invalid arguments');
+        }
+        var args = ['list', '-H', '-t', 'snapshot'];
+        if (snapshot) args.push(snapshot);
 
-	execFile(exports.paths.zfs, args, { timeout: timeoutDuration },
-	    function (error, stdout, stderr) {
-		if (error)
-			return (callback(zfsError(error, stderr)));
-		var rows = parseTabSeperatedTable(stdout);
-		return (callback(error, zfs.listFields_, rows));
-	});
+        execFile(exports.paths.zfs, args, { timeout: timeoutDuration },
+            function (error, stdout, stderr) {
+                if (error)
+                        return (callback(zfsError(error, stderr)));
+                var rows = parseTabSeperatedTable(stdout);
+                return (callback(error, zfs.listFields_, rows));
+        });
 };
 
 zfs.rollback = function (name, callback) {
-	if (arguments.length != 2)
-		throw Error('Invalid arguments');
+        if (arguments.length != 2)
+                throw Error('Invalid arguments');
 
-	execFile(exports.paths.zfs, ['rollback', '-r', name],
-	    { timeout: timeoutDuration },
-	    function (error, stdout, stderr) {
-		if (error)
-			return (callback(zfsError(error, stderr)));
-		return (callback());
-	});
+        execFile(exports.paths.zfs, ['rollback', '-r', name],
+            { timeout: timeoutDuration },
+            function (error, stdout, stderr) {
+                if (error)
+                        return (callback(zfsError(error, stderr)));
+                return (callback());
+        });
 };
 
 zfs.rename = function (name, newname, callback) {
-	if (arguments.length != 3)
-		throw Error('Invalid arguments');
+        if (arguments.length != 3)
+                throw Error('Invalid arguments');
 
-	execFile(exports.paths.zfs, [ 'rename', name, newname ],
-	    { timeout: timeoutDuration },
-	    function (error, stdout, stderr) {
-		if (error)
-			return (callback(zfsError(error, stderr)));
-		return (callback());
-	});
+        execFile(exports.paths.zfs, [ 'rename', name, newname ],
+            { timeout: timeoutDuration },
+            function (error, stdout, stderr) {
+                if (error)
+                        return (callback(zfsError(error, stderr)));
+                return (callback());
+        });
 };
 
 zfs.upgrade = function (name, version, callback) {
-	if (arguments.length === 2) {
-		callback = arguments[1];
-	} else if (arguments.length === 3) {
-		version = arguments[1];
-		callback = arguments[2];
-	} else {
-		throw Error('Invalid arguments');
-	}
+        if (arguments.length === 2) {
+                callback = arguments[1];
+        } else if (arguments.length === 3) {
+                version = arguments[1];
+                callback = arguments[2];
+        } else {
+                throw Error('Invalid arguments');
+        }
 
-	name = arguments[0];
+        name = arguments[0];
 
-	var args = [ 'upgrade' ];
-	if (version !== -1)
-		args.push(' -V ' + version);
-	args.push(name);
+        var args = [ 'upgrade' ];
+        if (version !== -1)
+                args.push(' -V ' + version);
+        args.push(name);
 
-	execFile(exports.paths.zfs, args, { timeout: timeoutDuration },
-	    function (error, stdout, stderr) {
-		if (error)
-			return (callback(new Error(stderr.toString())));
-		return (callback(null));
-	});
+        execFile(exports.paths.zfs, args, { timeout: timeoutDuration },
+            function (error, stdout, stderr) {
+                if (error)
+                        return (callback(new Error(stderr.toString())));
+                return (callback(null));
+        });
 };

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -130,7 +130,10 @@ piname_present_get_bootfs() {
 CURL="curl -s"
 
 # Well-known source of SmartOS Platform Images
-URL_PREFIX=https://us-east.manta.joyent.com/Joyent_Dev/public/SmartOS/
+DEFAULT_URL_PREFIX=https://us-east.manta.joyent.com/Joyent_Dev/public/SmartOS/
+
+# Can be overridden by the user's environment.
+URL_PREFIX=${URL_PREFIX:-${DEFAULT_URL_PREFIX}}
 
 # Scan for available installation media and mount it.
 mount_installmedia() {

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -56,7 +56,7 @@ vecho() {
 
 declare bootfs
 declare -a allbootfs
-declare -a numbootfs
+declare numbootfs
 #
 # Inventory pools and bootable file systems.
 #

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -257,21 +257,28 @@ remove() {
 copy_installmedia()
 {
     tdir=`mktemp -d`
+    tfile=`mktemp`
     bootdir=$1
 
-    # Try the USB key first, quietly...
-    mount_usb_key $tdir > /dev/null 2>&1 
+    # Try the USB key first, quietly and without $tdir/.joyentusb check...
+    mount_usb_key $tdir skip > $tfile 2>&1
     if [[ $? -ne 0 ]]; then
 	# If that fails, try mounting the ISO.
 	mount_ISO $tdir
 	if [[ $? -ne 0 ]]; then
 	    rmdir $tdir
-	    fatal "Can't find install media, please load one."
+	    echo "Can't find install media: ISO errors above, USB stick below."
+	    echo ""
+	    cat $tfile
+	    echo ""
+	    rm -f $tfile
+	    fatal "Can't find install media."
 	fi
 	usb=0
     else
 	usb=1
     fi
+    rm -f $tfile
 
     # Move it all over!
     tar -cf - -C $tdir . | tar -xf - -C /$bootdir

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -672,9 +672,10 @@ bootable() {
 		noslice=$(echo $a | sed -E 's/s[0-9]+//g')
 		tdir=`mktemp -d`
 		# Assume that s0 on the physical disk would be where the EFI
-		# System Partition (ESP) lives.  A pcfs mount can confirm/deny
-		# it.  Do this instead of just checkint for bootsize because
-		# we can further integrity-check here if need be.
+		# System Partition (ESP) lives.  A pcfs mount, ALONG WITH a
+		# check for a bootx64.efi executable, can confirm/deny it. Do
+		# this instead of just checkint for bootsize because we can
+		# further integrity-check here if need be.
 		mount -F pcfs /dev/dsk/${noslice}s0 $tdir > /dev/null 2>&1
 		if [[ $? -eq 0 && -f $tdir/EFI/Boot/bootx64.efi ]]; then
 		    efi="and UEFI"

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -158,9 +158,6 @@ mount_installmedia() {
 	    rm -f $tfile $tfile2
 	    return 1
 	fi
-	usb=0
-    else
-	usb=1
     fi
 
     rm -f $tfile $tfile2

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -297,7 +297,9 @@ install() {
     fi
 
     if [[ -e /${bootfs}/platform-${stamp} ]]; then
-	umount ${tdir}/mnt
+	if [[ "$iso" == "yes" ]]; then
+	    umount ${tdir}/mnt
+	fi
 	/bin/rm -rf ${tdir}
 	echo "PI-stamp $stamp appears to be already on /${bootfs}"
 	err "Use   piadm remove $stamp   to remove any old copies."
@@ -306,7 +308,9 @@ install() {
     tar -cf - -C ${tdir}/mnt/platform . | \
 	tar -xf - -C /${bootfs}/platform-${stamp}
 
-    umount ${tdir}/mnt
+    if [[ "$iso" == "yes" ]]; then
+	umount ${tdir}/mnt
+    fi
     /bin/rm -rf ${tdir}
 
     # Global variable for enablepool() usage...

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -218,6 +218,7 @@ install() {
 	    echo "Installing $1"
 	    echo "        (downloaded to $dload)"
 	    install $dload $2
+	    return 0
 	fi
 	# Else we treat it like a boot stamp.
 

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -31,7 +31,7 @@ usage() {
     echo "Usage: piadm [-v] <command> [command-specific arguments]"
     echo ""
     echo "    piadm activate|assign <PI-stamp> [ZFS-pool-name]"
-    echo "    piadm bootable [-d] [-e [-i <source>]] [ZFS-pool-name]"
+    echo "    piadm bootable [-d] [-e [-i <source>]] [-r] [ZFS-pool-name]"
     echo "    piadm install <source> [ZFS-pool-name]"
     echo "    piadm list <-H> [ZFS-pool-name]"
     echo "    piadm remove <PI-stamp> [ZFS-pool-name]"
@@ -623,6 +623,26 @@ enablepool() {
     activate $installstamp $pool
 }
 
+refreshpool() {
+    pool=$1
+
+    if [[ -z $pool ]]; then
+	echo "Must specify a pool for refresh"
+	usage
+    fi
+
+    currbootfs=""
+    # ispoolenabled sets currbootfs as a side-effect.
+    ispoolenabled $pool
+    if [[ $? -ne 0 ]]; then
+	fatal "Pool $pool is not bootable, and cannot be refreshed"
+    fi
+
+    update_boot_sectors $pool $currbootfs
+
+    exit 0
+}
+
 bootable() {
     if [[ "$1" == "-d" ]]; then
 	if [[ "$2" == "" ]]; then
@@ -645,6 +665,9 @@ bootable() {
     elif [[ "$1" == "-e" ]]; then
 	shift 1
 	enablepool $@
+	return
+    elif [[ "$1" == "-r" ]]; then
+	refreshpool $2
 	return
     fi
 

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -28,6 +28,121 @@ usage() {
     exit 1
 }
 
+declare -a allbootable
+declare -a numbootable
+getbootable() {
+    allbootable=$(zpool get -H bootfs $pool | grep -vw default | awk '{print $3}')
+    numbootable=${#allbootable[@]}
+}
+
+poolpresent() {
+    zpool list $1 > /dev/null 2>&1
+    if [[ $? -ne 0 ]]; then
+	echo "Pool $1 not present"
+	usage
+    fi
+}
+
+install_tarball() {
+    tarball=$1
+    bootfs=$2
+
+    tdir=`mktemp -d`
+    pushd $tdir > /dev/null
+    gtar -xzf $1
+
+    ## XXX KEBE SAYS INSPECT THE untarred directory for integrity, etc.
+    ## For now, however, assume:
+    ## - tarball only extracts to one directory.
+    ## - $DIR/etc/version/platform has `pistamp`.
+    ## - All of the other bits are in place properly (unix, boot archive, etc.)
+	
+    stamp=`cat */etc/version/platform`
+    if [[ -e /$bootfs/platform-$stamp ]]; then
+	echo "PI-stamp $stamp appears to exist on /$bootfs"
+	echo "Use:   piadm remove $stamp    before installing this one."
+	popd > /dev/null
+	/bin/rm -rf $tdir
+	usage
+    fi
+    mv * /$bootfs/platform-$stamp
+    popd > /dev/null
+    rmdir $tdir
+}
+
+# Well-known source of SmartOS Platform Images
+URL_PREFIX=https://us-east.manta.joyent.com/Joyent_Dev/public/SmartOS/
+
+install() {
+    ### XXX KEBE SAYS REFACTOR HERE...
+    getbootable
+    if [[ $numbootable -ne 1 && "$2" == "" ]]; then
+	echo "Multiple bootable pools are available, please specify one"
+	usage
+    elif [[ $numbootable -eq 1 ]]; then
+	bootfs=$allbootable
+	pool=$(echo $bootfs | awk -F/ '{print $1}')
+    else
+	pool=$2
+	bootfs=""
+	for check in $allbootable; do
+	    thispool=$(echo $check | awk -F/ '{print $1}')
+	    if [[ $thispool == $pool ]]; then
+		bootfs=$check
+		break
+	    fi
+	done
+	if [[ "$bootfs" == "" ]]; then
+	    echo "Pool $pool does not appear to be bootable."
+	    usage
+	fi
+    fi
+    poolpresent $pool
+
+    # echo "Installing $1 on pool $pool"
+
+    if [[ "$1" == "" ]]; then
+	echo "Must specify a Platform Image"
+	usage
+    fi
+    ### XXX KEBE SAYS END REFACTOR
+
+
+    # If .tgz, expand it.
+    if [[ -f $1 ]]; then
+	install_tarball $1 $bootfs
+	return 0
+    fi
+
+    # Special-case of "latest"
+    if [[ "$1" == "latest" ]]; then
+	# Well-known URL for the latest PI using conventions from URL_PREFIX.
+	url=${URL_PREFIX}/platform-latest.tgz
+    else
+	# Confirm this is a legitimate build stamp.
+	# Use conventions from site hosted in URL_PREFIX.
+	checkurl=${URL_PREFIX}/$1/index.html
+	curl -s $checkurl | head | grep -qv "not found"
+	if [[ $? -ne 0 ]]; then
+	    echo "PI-stamp $1 is invalid for download from $URL_PREFIX"
+	    usage
+	fi
+	pitar=`curl -s $checkurl | grep platform-release | grep tgz | awk -F\" '{print $2}'`
+	url=${URL_PREFIX}/$1/$pitar
+    fi
+
+    tfile=`mktemp`
+    curl -o $tfile $url
+    if [[ $? -ne 0 ]]; then
+	/bin/rm -f $tfile
+	echo "FETCH FAILED: curl -o $tfile $url"
+	usage
+    fi
+    mv $tfile ${tfile}.tgz
+    install_tarball ${tfile}.tgz $bootfs
+    /bin/rm -f ${tfile}.tgz
+}
+
 list() {
     if [[ $1 == "-H" ]]; then
 	pool=$2
@@ -37,13 +152,9 @@ list() {
 	pool=$1
     fi
 
-    zpool list $pool > /dev/null 2>&1
-    if [[ $? -ne 0 ]]; then
-	echo "Pool $pool not present"
-	usage
-    fi
+    poolpresent $pool
 
-    allbootable=$(zpool get -H bootfs $pool | grep -vw default | awk '{print $3}')
+    getbootable
     for bootfs in $allbootable; do
 	if [[ ! -L /$bootfs/platform ]]; then
 	    echo "WARNING: Bootable filesystem $bootfs has non-symlink platform"
@@ -70,6 +181,54 @@ list() {
     done
 }
 
+remove() {
+    ### XXX KEBE SAYS REFACTOR HERE...
+    getbootable
+    if [[ $numbootable -ne 1 && "$2" == "" ]]; then
+	echo "Multiple bootable pools are available, please specify one"
+	usage
+    elif [[ $numbootable -eq 1 ]]; then
+	bootfs=$allbootable
+	pool=$(echo $bootfs | awk -F/ '{print $1}')
+    else
+	pool=$2
+	bootfs=""
+	for check in $allbootable; do
+	    thispool=$(echo $check | awk -F/ '{print $1}')
+	    if [[ $thispool == $pool ]]; then
+		bootfs=$check
+		break
+	    fi
+	done
+	if [[ "$bootfs" == "" ]]; then
+	    echo "Pool $pool does not appear to be bootable."
+	    usage
+	fi
+    fi
+    poolpresent $pool
+
+    if [[ "$1" == "" ]]; then
+	echo "Must specify a Platform Image"
+	usage
+    fi
+    ### XXX KEBE SAYS END REFACTOR
+
+    pistamp=$1
+    cd /$bootfs
+    bootstamp=$(file -h platform | awk '{print $5}' | sed 's/\.\/platform-//g')
+
+    if [[ -d platform-$pistamp ]]; then
+	if [[ $bootstamp == $pistamp ]]; then
+	    echo "$pistamp is the current active PI. Please activate another PI"
+	    echo "using    piadm activate <other-PI-stamp>    first."
+	    usage
+	fi
+	/bin/rm -rf platform-$pistamp
+    else
+	echo "$pistamp is not a stamp for a PI on pool $pool"
+	usage
+    fi
+}
 
 #echo "Coming soon..."
 #usage
@@ -94,7 +253,7 @@ bootable )
     ;;
 
 install )
-    echo "Installing"
+    install $@
     ;;
 
 list )
@@ -102,7 +261,7 @@ list )
     ;;
 
 remove )
-    echo "Removing"
+    remove $@
     ;;
 
 *)
@@ -110,3 +269,5 @@ remove )
     ;;
 
 esac
+
+exit 0

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 Joyent, Inc.
+#
+
+usage() {
+    echo "Usage: piadm [-v] <command> [command-specific arguments]"
+    echo ""
+    echo "    piadm activate <PI-stamp> [ZFS-pool-name]"
+    echo "    piadm assign <PI-stamp> [ZFS-pool-name]"
+    echo "    piadm bootable [-d] [-e] [ZFS-pool-name]"
+    echo "    piadm install <PI-stamp,PI-tarball,PI-tarball-URL> [ZFS-pool-name]"
+    echo "    piadm list <-H> [ZFS-pool-name]"
+    echo "    piadm remove <PI-stamp> [ZFS-pool-name]"
+    echo ""
+    exit 1
+}
+
+list() {
+    if [[ $1 == "-H" ]]; then
+	pool=$2
+    else
+	printf "%-18s %-30s %-12s %-12s \n" "PI STAMP" "BOOTABLE FILESYSTEM"  \
+	       "BOOTED NOW" "BOOTS NEXT"
+	pool=$1
+    fi
+
+    zpool list $pool > /dev/null 2>&1
+    if [[ $? -ne 0 ]]; then
+	echo "Pool $pool not present"
+	usage
+    fi
+
+    allbootable=$(zpool get -H bootfs $pool | grep -vw default | awk '{print $3}')
+    for bootfs in $allbootable; do
+	if [[ ! -L /$bootfs/platform ]]; then
+	    echo "WARNING: Bootable filesystem $bootfs has non-symlink platform"
+	    exit 1
+	fi
+	cd /$bootfs
+	bootstamp=$(file -h platform | awk '{print $5}' | \
+			sed 's/\.\/platform-//g')
+	activestamp=$(uname -v | sed 's/joyent_//g')
+	pis=$(cd /$bootfs ; ls -d platform-* | sed 's/platform-//g')
+	for pi in $pis; do
+	    if [[ $activestamp == $pi ]]; then
+		active="yes"
+	    else
+		active="no"
+	    fi
+	    if [[ $bootstamp == $pi ]]; then
+		booting="yes"
+	    else
+		booting="no"
+	    fi
+	    printf "%-18s %-30s %-12s %-12s\n" $pi $bootfs $active $booting
+	done
+    done
+}
+
+
+#echo "Coming soon..."
+#usage
+
+if [[ "$1" == "-v" ]]; then
+    DEBUG=1
+    shift 1
+else
+    DEBUG=0
+fi
+
+cmd=$1
+shift 1
+
+case $cmd in
+activate | assign )
+    echo "Activating/assigning"
+    ;;
+
+bootable )
+    echo "Doing bootable check or upgrade"
+    ;;
+
+install )
+    echo "Installing"
+    ;;
+
+list )
+    list $@
+    ;;
+
+remove )
+    echo "Removing"
+    ;;
+
+*)
+    usage
+    ;;
+
+esac

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -126,8 +126,8 @@ piname_present_get_bootfs() {
     fi
 }
 
-# Use "-k" for now until we ship CAs with the Platform Image again.
-CURL="curl -k"
+# Defined as a variable in case we need to add parameters (like -s) to it.
+CURL="curl -s"
 
 # Well-known source of SmartOS Platform Images
 URL_PREFIX=https://us-east.manta.joyent.com/Joyent_Dev/public/SmartOS/
@@ -187,7 +187,7 @@ install() {
 	# Grab the latest-version ISO.  Before proceeding, make sure it's the
 	# current one.
 	iso=yes
-	${CURL} -s -o ${tdir}/smartos.iso ${URL_PREFIX}/smartos-latest.iso
+	${CURL} -o ${tdir}/smartos.iso ${URL_PREFIX}/smartos-latest.iso
 	mount -F hsfs ${tdir}/smartos.iso ${tdir}/mnt
 
 	# For now, assume boot stamp and PI stamp are the same on an ISO...
@@ -237,7 +237,7 @@ install() {
 	# Explicit boot stamp or URL.
 
 	# Do a URL reality check.
-	${CURL} -s -o ${tdir}/download $1
+	${CURL} -o ${tdir}/download $1
 	if [[ -e ${tdir}/download ]]; then
 	    # Recurse with the downloaded file.
 	    dload=`mktemp`
@@ -264,12 +264,12 @@ install() {
 	# Confirm this is a legitimate build stamp.
 	# Use conventions from site hosted in URL_PREFIX.
 	checkurl=${URL_PREFIX}/$1/index.html
-	${CURL} -s $checkurl | head | grep -qv "not found"
+	${CURL} $checkurl | head | grep -qv "not found"
 	if [[ $? -ne 0 ]]; then
 	    echo "PI-stamp $1 is invalid for download from $URL_PREFIX"
 	    usage
 	fi
-	${CURL} -s -o ${tdir}/smartos.iso ${URL_PREFIX}/$1/smartos-${1}.iso
+	${CURL} -o ${tdir}/smartos.iso ${URL_PREFIX}/$1/smartos-${1}.iso
 	mount -F hsfs ${tdir}/smartos.iso ${tdir}/mnt
 	iso=yes
 	stamp=$1

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -506,6 +506,11 @@ activate() {
 	vecho "	   with a new boot image,"
     else
 	vecho "	   WARNING:  $pistamp has no matching boot image, using"
+	if [[ ! -f etc/version/boot ]]; then
+	    fatal "No boot version available on /$bootfs"
+	elif [[ ! -d boot/. ]]; then
+	    fatal "No boot bits directory on /$bootfs"
+	fi
     fi
 
     vecho "    boot image " $(cat etc/version/boot)

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -18,45 +18,45 @@
 . /lib/sdc/usb-key.sh
 
 eecho() {
-    echo $@ > /dev/stderr
+	echo $@ 1>&2
 }
 
 err() {
-    eecho $1
-    exit 1
+	eecho $1
+	exit 1
 }
 
 fatal() {
-    eecho
-    if [[ -n "$1" ]]; then
-	eecho "ERROR: $1"
-    fi
-    eecho
-    exit 2
+	eecho
+	if [[ -n "$1" ]]; then
+		eecho "ERROR: $1"
+	fi
+	eecho
+	exit 2
 }
 
 corrupt() {
-    eecho $1
-    exit 3
+	eecho $1
+	exit 3
 }
 
 usage() {
-    eecho ""
-    eecho "Usage: piadm [-v] <command> [command-specific arguments]"
-    eecho ""
-    eecho "    piadm activate|assign <PI-stamp> [ZFS-pool-name]"
-    eecho "    piadm bootable [-d] [-e [-i <source>]] [-r] [ZFS-pool-name]"
-    eecho "    piadm install <source> [ZFS-pool-name]"
-    eecho "    piadm list <-H> [ZFS-pool-name]"
-    eecho "    piadm remove <PI-stamp> [ZFS-pool-name]"
-    err ""
+	eecho ""
+	eecho "Usage: piadm [-v] <command> [command-specific arguments]"
+	eecho ""
+	eecho "    piadm activate|assign <PI-stamp> [ZFS-pool-name]"
+	eecho "    piadm bootable [-d] [-e [-i <source>]] [-r] [ZFS-pool-name]"
+	eecho "    piadm install <source> [ZFS-pool-name]"
+	eecho "    piadm list <-H> [ZFS-pool-name]"
+	eecho "    piadm remove <PI-stamp> [ZFS-pool-name]"
+	err ""
 }
 
 vecho() {
-    if [[ $VERBOSE -eq 1 ]]; then
-	# Verbose echoes invoked by -v go to stdout, not stderr.
-	echo $@
-    fi
+	if [[ $VERBOSE -eq 1 ]]; then
+		# Verbose echoes invoked by -v go to stdout, not stderr.
+		echo $@
+	fi
 }
 
 declare bootfs
@@ -66,11 +66,11 @@ declare numbootfs
 # Inventory pools and bootable file systems.
 #
 getbootable() {
-    IFS=" "
-    # Use `mapfile -t` so bash array constructs can work.
-    mapfile -t allbootfs \
-	    < <(zpool get -H bootfs | awk '{if ($3 != "-") print $3}')
-    numbootfs=${#allbootfs[@]}
+	IFS=" "
+	# Use `mapfile -t` so bash array constructs can work.
+	mapfile -t allbootfs < <(zpool list -Ho name,bootfs | \
+		awk '{if ($2 != "-") print $2 }')
+	numbootfs=${#allbootfs[@]}
 }
 
 declare activestamp
@@ -78,12 +78,12 @@ activestamp=$(uname -v | sed 's/joyent_//g')
 declare installstamp
 
 poolpresent() {
-    # Works for an empty $1, which is "all of them" or "unspecified"
-    zpool list $1 > /dev/null 2>&1
-    if [[ $? -ne 0 ]]; then
-	eecho "Pool $1 not present"
-	usage
-    fi
+	# Works for an empty $1, which is "all of them" or "unspecified"
+	zpool list $1 > /dev/null 2>&1
+	if [[ $? -ne 0 ]]; then
+		eecho "Pool $1 not present"
+		usage
+	fi
 }
 
 # Common-code to obtain the bootable filesystem, and setting $bootfs
@@ -91,44 +91,44 @@ poolpresent() {
 # Takes a PI name or source name (which must not be blank) AND a pool
 # (which can).
 piname_present_get_bootfs() {
-    if [[ "$1" == "" ]]; then
-	eecho "Must specify a Platform Image"
-	usage
-    fi
-
-    poolpresent $pool
-
-    getbootable
-    if [[ $numbootfs -gt 1 && "$2" == "" ]]; then
-	eecho "Multiple bootable pools are available, please specify one"
-	usage
-    elif [[ "$2" == "" ]]; then
-	# If we reach here, no more than one bootable pool.
-	bootfs=$allbootfs
-	if [[ "$bootfs" == "" ]]; then
-	    eecho "No bootable pools available..."
-	    usage
+	if [[ "$1" == "" ]]; then
+		eecho "Must specify a Platform Image"
+		usage
 	fi
-	pool=$(echo $bootfs | awk -F/ '{print $1}')
-	vecho "Selecting lone boot pool $pool by default."
-    else
-	# If we reach here, the CLI specifies a known-present (passes
-	# poolpresent()) pool in $2 and we have at least one to check
-	# against..
-	pool=$2
-	bootfs=""
-	for check in ${allbootfs[@]}; do
-	    thispool=$(echo $check | awk -F/ '{print $1}')
-	    if [[ $thispool == $pool ]]; then
-		bootfs=$check
-		break
-	    fi
-	done
-	if [[ "$bootfs" == "" ]]; then
-	    eecho "Pool $pool does not appear to be bootable."
-	    usage
+
+	poolpresent $pool
+
+	getbootable
+	if [[ $numbootfs -gt 1 && "$2" == "" ]]; then
+		eecho "Multiple bootable pools are available, please specify one"
+		usage
+	elif [[ "$2" == "" ]]; then
+		# If we reach here, no more than one bootable pool.
+		bootfs=$allbootfs
+		if [[ "$bootfs" == "" ]]; then
+			eecho "No bootable pools available..."
+			usage
+		fi
+		pool=$(echo $bootfs | awk -F/ '{print $1}')
+		vecho "Selecting lone boot pool $pool by default."
+	else
+		# If we reach here, the CLI specifies a known-present (passes
+		# poolpresent()) pool in $2 and we have at least one to check
+		# against..
+		pool=$2
+		bootfs=""
+		for check in ${allbootfs[@]}; do
+			thispool=$(echo $check | awk -F/ '{print $1}')
+			if [[ $thispool == $pool ]]; then
+			    bootfs=$check
+			    break
+			fi
+		done
+		if [[ "$bootfs" == "" ]]; then
+			eecho "Pool $pool does not appear to be bootable."
+			usage
+		fi
 	fi
-    fi
 }
 
 # Defined as a variable in case we need to add parameters (like -s) to it.
@@ -143,33 +143,33 @@ URL_PREFIX=${PIADM_URL_PREFIX:-${DEFAULT_URL_PREFIX}}
 
 # Scan for available installation media and mount it.
 mount_installmedia() {
-    tfile=$(mktemp)
-    tfile2=$(mktemp)
+	tfile=$(mktemp)
+	tfile2=$(mktemp)
 
-    mntdir=$1
+	mntdir=$1
 
-    # Try the USB key first, quietly and without $mntdir/.joyentusb check...
-    mount_usb_key $mntdir skip > $tfile 2>&1
-    if [[ $? -ne 0 ]]; then
-	# If that fails, try mounting the ISO.
-	mount_ISO $mntdir > $tfile2 2>&1
+	# Try the USB key first, quietly and without $mntdir/.joyentusb check
+	mount_usb_key $mntdir skip > $tfile 2>&1
 	if [[ $? -ne 0 ]]; then
-	    if [[ $VERBOSE -eq 1 ]]; then
-		eecho "Can't find install media: USB stick errors:"
-		eecho ""
-		cat $tfile > /dev/stderr
-		eecho ""
-		eecho "ISO errors"
-		eecho ""
-		cat $tfile2 > /dev/stderr
-	    fi
-	    rm -f $tfile $tfile2
-	    return 1
+		# If that fails, try mounting the ISO.
+		mount_ISO $mntdir > $tfile2 2>&1
+		if [[ $? -ne 0 ]]; then
+			if [[ $VERBOSE -eq 1 ]]; then
+			    eecho "Can't find install media: USB stick errors:"
+			    eecho ""
+			    cat $tfile 1>&2
+			    eecho ""
+			    eecho "ISO errors"
+			    eecho ""
+			    cat $tfile2 1>&2
+			fi
+			rm -f $tfile $tfile2
+			return 1
+		fi
 	fi
-    fi
 
-    rm -f $tfile $tfile2
-    return 0
+	rm -f $tfile $tfile2
+	return 0
 }
 
 # Install a Platform Image.
@@ -177,596 +177,627 @@ mount_installmedia() {
 # XXX WARNING - there is a security discussion to be had about the integrity
 # of the source.
 install() {
-    piname_present_get_bootfs $1 $2
-    tdir=$(mktemp -d)
-    mkdir ${tdir}/mnt
+	piname_present_get_bootfs $1 $2
+	tdir=$(mktemp -d)
+	mkdir ${tdir}/mnt
 
-    # $1 contains a "source".  Deal with it correctly in the big
-    # if/elif/else block.  Once done, we can copy over bits into $tdir or
-    # ${tdir}/mnt.
-    # 
+	# $1 contains a "source".  Deal with it correctly in the big
+	# if/elif/else block.  Once done, we can copy over bits into $tdir or
+	# ${tdir}/mnt.
+	# 
 
-    # Special-case of "latest"
-    if [[ "$1" == "latest" ]]; then
-	# Well-known URL for the latest PI using conventions from URL_PREFIX.
-	# Grab the latest-version ISO.	Before proceeding, make sure it's the
-	# current one.
-	iso=yes
-	${CURL} -o ${tdir}/smartos.iso ${URL_PREFIX}/smartos-latest.iso
-	if [[ $? -ne 0 ]]; then
-	    /bin/rm -rf ${tdir}
-	    fatal "Curl exit code $?"
-	fi
-	mount -F hsfs ${tdir}/smartos.iso ${tdir}/mnt
+	# Special-case of "latest"
+	if [[ "$1" == "latest" ]]; then
+		# Well-known URL for the latest PI using conventions from
+		# URL_PREFIX.  Grab the latest-version ISO. Before proceeding,
+		# make sure it's the current one.
+		iso=yes
+		${CURL} -o ${tdir}/smartos.iso ${URL_PREFIX}/smartos-latest.iso
+		if [[ $? -ne 0 ]]; then
+			code=$?
+			/bin/rm -rf ${tdir}
+			fatal "Curl exit code $code"
+		fi
+		mount -F hsfs ${tdir}/smartos.iso ${tdir}/mnt
 
-	# For now, assume boot stamp and PI stamp are the same on an ISO...
-	stamp=$(cat ${tdir}/mnt/etc/version/boot)
-    elif [[ "$1" == "media" ]]; then
-	# Scan the available media to find what we seek.  Same advice
-	# about making sure it's the current one.
-	iso=yes
-	mount_installmedia ${tdir}/mnt
-	if [[ $? -ne 0 ]]; then
-	    /bin/rm -rf ${tdir}
-	    err "Cannot find install media"
-	fi
+		# For now, assume boot stamp and PI stamp are the same on an ISO...
+		stamp=$(cat ${tdir}/mnt/etc/version/boot)
+	elif [[ "$1" == "media" ]]; then
+		# Scan the available media to find what we seek.  Same advice
+		# about making sure it's the current one.
+		iso=yes
+		mount_installmedia ${tdir}/mnt
+		if [[ $? -ne 0 ]]; then
+			/bin/rm -rf ${tdir}
+			err "Cannot find install media"
+		fi
 
-	# For now, assume boot stamp and PI stamp are the same on
-	# install media.
-	stamp=$(cat ${tdir}/mnt/etc/version/boot)
-    elif [[ -f $1 ]]; then
-	# File input!  Check for what kind, etc. etc.
+		# For now, assume boot stamp and PI stamp are the same on
+		# install media.
+		stamp=$(cat ${tdir}/mnt/etc/version/boot)
+	elif [[ -f $1 ]]; then
+		# File input!  Check for what kind, etc. etc.
 
-	# WARNING:  Depends GREATLY on the output of file(1)
-	filetype=$(file $1 | awk '{print $2}')
-	if [[ "$filetype" == "ISO" ]]; then
-	    # Assume .iso file.
-	    iso=yes
-	    mount -F hsfs $1 ${tdir}/mnt
-	    stamp=$(cat ${tdir}/mnt/etc/version/boot)
-	elif [[ "$filetype" == "gzip" ]]; then
-	    # SmartOS PI.  Let's confirm it's actually a .tgz...
-	    gtar -xzOf $1 > /dev/null 2>&1
-	    if [[ $? -ne 0 ]]; then
-		/bin/rm -rf ${tdir}
-		err "File $1 is not an ISO or a .tgz file."
-	    fi
-	    # We're most-likely good here.
-	    # NOTE: SmartOS/Triton PI files expand to platform-$STAMP.
-	    # Fix it here before proceeding.
-	    gtar -xzf $1 -C ${tdir}/mnt
-	    mv ${tdir}/mnt/platform-* ${tdir}/mnt/platform
-	    iso=no
-	    stamp=$(cat ${tdir}/mnt/platform/etc/version/platform)
+		# WARNING:  Depends GREATLY on the output of file(1)
+		filetype=$(file $1 | awk '{print $2}')
+		if [[ "$filetype" == "ISO" ]]; then
+			# Assume .iso file.
+			iso=yes
+			mount -F hsfs $1 ${tdir}/mnt
+			stamp=$(cat ${tdir}/mnt/etc/version/boot)
+		elif [[ "$filetype" == "gzip" ]]; then
+			# SmartOS PI.  Let's confirm it's actually a .tgz...
+			gtar -xzOf $1 > /dev/null 2>&1
+			if [[ $? -ne 0 ]]; then
+				/bin/rm -rf ${tdir}
+				err "File $1 is not an ISO or a .tgz file."
+			fi
+			# We're most-likely good here.  NOTE: SmartOS/Triton
+			# PI files expand to platform-$STAMP.  Fix it here
+			# before proceeding.
+			gtar -xzf $1 -C ${tdir}/mnt
+			mv ${tdir}/mnt/platform-* ${tdir}/mnt/platform
+			iso=no
+			stamp=$(cat ${tdir}/mnt/platform/etc/version/platform)
+		else
+			/bin/rm -rf ${tdir}
+			err "Unknown file type for $1"
+		fi
 	else
-	    /bin/rm -rf ${tdir}
-	    err "Unknown file type for $1"
-	fi
-    else
-	# Explicit boot stamp or URL.
+		# Explicit boot stamp or URL.
 
-	# Do a URL reality check.
-	${CURL} -o ${tdir}/download $1
-	if [[ -e ${tdir}/download ]]; then
-	    # Recurse with the downloaded file.
-	    dload=$(mktemp)
-	    mv -f ${tdir}/download $dload
-	    /bin/rm -rf ${tdir}
+		# Do a URL reality check.
+		${CURL} -o ${tdir}/download $1
+		if [[ -e ${tdir}/download ]]; then
+			# Recurse with the downloaded file.
+			dload=$(mktemp)
+			mv -f ${tdir}/download $dload
+			/bin/rm -rf ${tdir}
 
-	    # in case `install` exits out early...
-	    ( pwait $$ ; rm -f $dload ) &
-	    vecho "Installing $1"
-	    vecho "	   (downloaded to $dload)"
-	    install $dload $2
-	    return 0
-	fi
-	# Else we treat it like a boot stamp.
+			# in case `install` exits out early...
+			( pwait $$ ; rm -f $dload ) &
+			vecho "Installing $1"
+			vecho "	   (downloaded to $dload)"
+			install $dload $2
+			return 0
+		fi
+		# Else we treat it like a boot stamp.
 
-	# Now that we think it's a boot stamp, check if it's the
-	# current one or if it exists.
-	if [[ -d ${bootfs}/platform-${1} ]]; then
-	    /bin/rm -rf ${tdir}
-	    eecho "PI-stamp $1 appears to be already on /${bootfs}"
-	    err "Use   piadm remove $1	 to remove any old copies."
-	fi
+		# Now that we think it's a boot stamp, check if it's the
+		# current one or if it exists.
+		if [[ -d ${bootfs}/platform-${1} ]]; then
+			/bin/rm -rf ${tdir}
+			eecho "PI-stamp $1 appears to be already on /${bootfs}"
+			err "Use  piadm remove $1  to remove any old copies."
+		fi
 
-	# Confirm this is a legitimate build stamp.
-	# Use conventions from site hosted in URL_PREFIX.
-	checkurl=${URL_PREFIX}/$1/index.html
-	${CURL} $checkurl | head | grep -qv "not found"
-	if [[ $? -ne 0 ]]; then
-	    eecho "PI-stamp $1 is invalid for download from $URL_PREFIX"
-	    usage
-	fi
-	${CURL} -o ${tdir}/smartos.iso ${URL_PREFIX}/$1/smartos-${1}.iso
-	if [[ $? -ne 0 ]]; then
-	    /bin/rm -rf ${tdir}
-	    fatal "Curl exit code $?"
-	fi
-	mount -F hsfs ${tdir}/smartos.iso ${tdir}/mnt
-	iso=yes
-	stamp=$1
-	# Reality-check boot stamp.
-	bstamp=$(cat ${tdir}/mnt/etc/version/boot)
-	if [[ "$stamp" != "$bstamp" ]]; then
-	    umount ${tdir}/mnt
-	    /bin/rm -rf ${tdir}
-	    err "Boot bits stamp says $bstamp, vs. argument stamp $stamp"
-	fi
-    fi
-
-    vecho "Installing PI $stamp"
-
-    # At this point we have ${tdir}/mnt which contains at least "platform".
-    # If "iso" is yes, it also contains "boot", "boot.catalog" and "etc", but
-    # we only really care about boot.catalog and boot.	These may be mounted
-    # as read-only, so we can't do mv.
-
-    if [[ "$iso" == "yes" ]]; then
-	# Match-check boot stamp and platform stamp.
-	pstamp=$(cat ${tdir}/mnt/platform/etc/version/platform)
-	if [[ "$stamp" != "$pstamp" ]];	then
-	    umount ${tdir}/mnt
-	    /bin/rm -rf ${tdir}
-	    err "Boot stamp $stamp mismatches platform stamp $pstamp"
+		# Confirm this is a legitimate build stamp.
+		# Use conventions from site hosted in URL_PREFIX.
+		checkurl=${URL_PREFIX}/$1/index.html
+		${CURL} $checkurl | head | grep -qv "not found"
+		if [[ $? -ne 0 ]]; then
+			eecho "PI-stamp $1" \
+				"is invalid for download from $URL_PREFIX"
+			usage
+		fi
+		${CURL} -o ${tdir}/smartos.iso \
+			${URL_PREFIX}/$1/smartos-${1}.iso
+		if [[ $? -ne 0 ]]; then
+			code=$?
+			/bin/rm -rf ${tdir}
+			fatal "PI-stamp $1 -- curl exit code $code"
+		fi
+		mount -F hsfs ${tdir}/smartos.iso ${tdir}/mnt
+		if [[ $? -ne 0 ]]; then
+			code=$?
+			/bin/rm -rf ${tdir}
+			fatal "PI-stamp $1 -- mount exit code $code"
+		fi
+		iso=yes
+		stamp=$1
+		# Reality-check boot stamp.
+		bstamp=$(cat ${tdir}/mnt/etc/version/boot)
+		if [[ "$stamp" != "$bstamp" ]]; then
+			umount ${tdir}/mnt
+			/bin/rm -rf ${tdir}
+			err "Boot bits stamp says $bstamp," \
+			    "vs. argument stamp $stamp"
+		fi
 	fi
 
-	if [[ -e /${bootfs}/boot-${stamp} ]]; then
-	    umount ${tdir}/mnt
-	    /bin/rm -rf ${tdir}
-	    eecho "PI-stamp $stamp has boot bits already on /${bootfs}"
-	    err "Use   piadm remove $stamp   to remove any old copies."
-	fi
-	mkdir /${bootfs}/boot-${stamp} || \
-	    eecho "Can't mkdir /${bootfs}/boot-${stamp}"
-	tar -cf - -C ${tdir}/mnt/boot . | \
-	    tar -xf - -C /${bootfs}/boot-${stamp} || \
-	    eecho "Problem in tar of boot bits"
-    fi
+	vecho "Installing PI $stamp"
 
-    if [[ -e /${bootfs}/platform-${stamp} ]]; then
+	# At this point we have ${tdir}/mnt which contains at least
+	# "platform".  If "iso" is yes, it also contains "boot",
+	# "boot.catalog" and "etc", but we only really care about boot.catalog
+	# and boot. These may be mounted as read-only, so we can't do mv.
+
 	if [[ "$iso" == "yes" ]]; then
-	    umount ${tdir}/mnt
+		# Match-check boot stamp and platform stamp.
+		pstamp=$(cat ${tdir}/mnt/platform/etc/version/platform)
+		if [[ "$stamp" != "$pstamp" ]];	then
+			umount ${tdir}/mnt
+			/bin/rm -rf ${tdir}
+			err "Boot stamp $stamp mismatches platform stamp" \
+				"$pstamp"
+		fi
+
+		if [[ -e /${bootfs}/boot-${stamp} ]]; then
+			umount ${tdir}/mnt
+			/bin/rm -rf ${tdir}
+			eecho "PI-stamp $stamp has boot bits already" \
+				"on /${bootfs}"
+			err "Use  piadm remove $stamp " \
+				"to remove any old copies."
+		fi
+		mkdir /${bootfs}/boot-${stamp} || \
+			eecho "Can't mkdir /${bootfs}/boot-${stamp}"
+		tar -cf - -C ${tdir}/mnt/boot . | \
+			tar -xf - -C /${bootfs}/boot-${stamp} || \
+			eecho "Problem in tar of boot bits"
+	fi
+
+	if [[ -e /${bootfs}/platform-${stamp} ]]; then
+		if [[ "$iso" == "yes" ]]; then
+			umount ${tdir}/mnt
+		fi
+		/bin/rm -rf ${tdir}
+		eecho "PI-stamp $stamp appears to be already on /${bootfs}"
+		err "Use   piadm remove $stamp	 to remove any old copies."
+	fi
+	mkdir /${bootfs}/platform-${stamp} || \
+		eecho "Can't mkdir /${bootfs}/platform-${stamp}"
+	tar -cf - -C ${tdir}/mnt/platform . | \
+		tar -xf - -C /${bootfs}/platform-${stamp} || \
+		eecho "Problem in tar of platform bits"
+
+	if [[ "$iso" == "yes" ]]; then
+		umount ${tdir}/mnt
 	fi
 	/bin/rm -rf ${tdir}
-	eecho "PI-stamp $stamp appears to be already on /${bootfs}"
-	err "Use   piadm remove $stamp	 to remove any old copies."
-    fi
-    mkdir /${bootfs}/platform-${stamp} || \
-	eecho "Can't mkdir /${bootfs}/platform-${stamp}"
-    tar -cf - -C ${tdir}/mnt/platform . | \
-	tar -xf - -C /${bootfs}/platform-${stamp} || \
-	eecho "Problem in tar of platform bits"
 
-    if [[ "$iso" == "yes" ]]; then
-	umount ${tdir}/mnt
-    fi
-    /bin/rm -rf ${tdir}
+	if [[ ! -d /${bootfs}/platform-${stamp} ]]; then
+		fatal "Installation problem (no ${bootfs}/platform-${stamp})"
+	fi
+	if [[ ! -d /${bootfs}/boot-${stamp} && "$iso" == "yes" ]]; then
+		fatal "Installation problem (no ${bootfs}/boot-${stamp}" \
+			"from ISO)"
+	fi
 
-    if [[ ! -d /${bootfs}/platform-${stamp} ]]; then
-	fatal "Installation problem (no ${bootfs}/platform-${stamp})"
-    fi
-    if [[ ! -d /${bootfs}/boot-${stamp} && "$iso" == "yes" ]]; then
-	fatal "Installation problem (no ${bootfs}/boot-${stamp} from ISO)"
-    fi
-
-    # Global variable for enablepool() usage...
-    installstamp=$stamp
-    return 0
+	# Global variable for enablepool() usage...
+	installstamp=$stamp
+	return 0
 }
 
 list() {
-    if [[ $1 == "-H" ]]; then
-	pool=$2
-    else
-	printf "%-18s %-30s %-12s %-5s %-5s \n" "PI STAMP" \
-	       "BOOTABLE FILESYSTEM" "BOOT BITS?" "NOW" "NEXT"
-	pool=$1
-    fi
-
-    poolpresent $pool
-
-    getbootable
-    for bootfs in ${allbootfs[@]}; do
-	bfspool=$(echo $bootfs | awk -F/ '{print $1}')
-	if [[ "$pool" != "" && "$bfspool" != "$pool" ]]; then
-	    # If we specify a pool for listing, skip ones not in the pool.
-	    continue
+	if [[ $1 == "-H" ]]; then
+		pool=$2
+	else
+		printf "%-18s %-30s %-12s %-5s %-5s \n" "PI STAMP" \
+			"BOOTABLE FILESYSTEM" "BOOT BITS?" "NOW" "NEXT"
+		pool=$1
 	fi
-	if [[ ! -L /$bootfs/platform ]]; then
-	    corrupt \
-		"WARNING: Bootable filesystem $bootfs has non-symlink platform"
-	fi
-	cd /$bootfs
-	bootbitsstamp=$(cat etc/version/boot)
-	bootstamp=$(cat platform/etc/version/platform)
-	mapfile -t pis \
-		< <(cd /$bootfs ; cat platform-*/etc/version/platform)
-	for pi in ${pis[@]}; do
-	    if [[ $activestamp == $pi ]]; then
-		active="yes"
-	    else
-		active="no"
-	    fi
-	    if [[ $bootstamp == $pi ]]; then
-		booting="yes"
-	    else
-		booting="no"
-	    fi
-	    if [[ $bootbitsstamp == $pi ]]; then
-		bootbits="next"
-	    elif [[ -d boot-$pi ]]; then
-		bootbits="available"
-	    else
-		bootbits="none"
-	    fi
-	    printf "%-18s %-30s %-12s %-5s %-5s\n" $pi $bootfs $bootbits \
-		   $active $booting
+
+	poolpresent $pool
+
+	getbootable
+	for bootfs in ${allbootfs[@]}; do
+		bfspool=$(echo $bootfs | awk -F/ '{print $1}')
+		if [[ "$pool" != "" && "$bfspool" != "$pool" ]]; then
+			# If we specify a pool for listing, skip ones not in
+			# the pool.
+			continue
+		fi
+		if [[ ! -L /$bootfs/platform ]]; then
+			corrupt "WARNING: Bootable filesystem $bootfs" \
+				"has non-symlink platform"
+		fi
+		cd /$bootfs
+		bootbitsstamp=$(cat etc/version/boot)
+		bootstamp=$(cat platform/etc/version/platform)
+		mapfile -t pis \
+			< <(cd /$bootfs ; cat platform-*/etc/version/platform)
+		for pi in ${pis[@]}; do
+			if [[ $activestamp == $pi ]]; then
+				active="yes"
+			else
+			    active="no"
+			fi
+			if [[ $bootstamp == $pi ]]; then
+				booting="yes"
+			else
+				booting="no"
+			fi
+			if [[ $bootbitsstamp == $pi ]]; then
+				bootbits="next"
+			elif [[ -d boot-$pi ]]; then
+				bootbits="available"
+			else
+				bootbits="none"
+			fi
+			printf "%-18s %-30s %-12s %-5s %-5s\n" \
+				$pi $bootfs $bootbits $active $booting
+		done
 	done
-    done
 }
 
 update_boot_sectors() {
-    pool=$1
-    bootfs=$2
+	pool=$1
+	bootfs=$2
 
-    # XXX WARNING -- illumos#12894 will allow slogs.  We will need to
-    # alter the generation of boot_devices accordingly.
-    # Generate the pool's boot devices now, in case we did something
-    # hyper-clever for the pool.  s1 may be created, but not yet PCFS...
-    mapfile -t boot_devices < <(zpool list -v "$pool" | \
-	    grep -E 'c[0-9]+' | awk '{print $1}' | sed -E 's/s[0-9]+//g')
+	# XXX WARNING -- illumos#12894 will allow slogs.  We will need to
+	# alter the generation of boot_devices accordingly.  Generate the
+	# pool's boot devices now, in case we did something hyper-clever for
+	# the pool.  s1 may be created, but not yet PCFS...
+	mapfile -t boot_devices < <(zpool list -vHP "$pool" | \
+		grep -E 'c[0-9]+' | awk '{print $1}' | sed -E 's/s[0-9]+//g')
 
-    # Reality check the pool was created with -B.
-    # First way to do this is to check for the `bootsize` property not
-    # its default, which is NO bootsize.
-    if [[ $(zpool list -Ho bootsize $pool) == "-" ]]; then
-	# No bootsize is a first-cut test.  It passes if the pool was
-	# created with `zpool create -B`. There's one other that needs
-	# to be performed, because some bootable pools are manually
-	# configured to share slices with other functions (slog,
-	# l2arc, dedup):
+	# Reality check the pool was created with -B.
+	# First way to do this is to check for the `bootsize` property not
+	# its default, which is NO bootsize.
+	if [[ $(zpool list -Ho bootsize $pool) == "-" ]]; then
+		# No bootsize is a first-cut test.  It passes if the pool was
+		# created with `zpool create -B`. There's one other that needs
+		# to be performed, because some bootable pools are manually
+		# configured to share slices with other functions (slog,
+		# l2arc, dedup):
 
-	# Use fstyp to confirm if this is a manually created EFI
-	# System Partition (ESP)
-	type=$(fstyp /dev/dsk/${boot_devices[0]}s0)
-	if [[ "$type" == "pcfs" ]]; then
-	    # If we detect PCFS on s0, it's LIKELY an EFI System Partition that
-	    # was crafted manually.  Use s1 if it's ZFS, or bail if it's not.
+		# Use fstyp to confirm if this is a manually created EFI
+		# System Partition (ESP)
+		type=$(fstyp /dev/dsk/${boot_devices[0]}s0)
+		if [[ "$type" == "pcfs" ]]; then
+			# If we detect PCFS on s0, it's LIKELY an EFI System
+			# Partition that was crafted manually.  Use s1 if it's
+			# ZFS, or bail if it's not.
 
-	    s1type=$(fstyp /dev/dsk/${boot_devices[0]}s1)
-	    if [[ "$s1type" != "zfs" ]]; then
-		fatal "Unusual configuration, ${boot_devices[0]}s1 not ZFS"
-	    fi
-	    suffix=s1
+			s1type=$(fstyp /dev/dsk/${boot_devices[0]}s1)
+			if [[ "$s1type" != "zfs" ]]; then
+				fatal "Unusual configuration," \
+					"${boot_devices[0]}s1 not ZFS"
+			fi
+			suffix=s1
+		else
+			suffix=s0
+		fi
 	else
-	    suffix=s0
+		# Guaranteed that s0 is EFI System Partition, ZFS lives on s1.
+		suffix=s1
 	fi
-    else
-	# Guaranteed that s0 is EFI System Partition, ZFS lives on s1.
-	suffix=s1
-    fi
 
-    some=0
-    for a in "${boot_devices[@]}"; do
-	# Plow through devices, even if some fail.  installboot also
-	# does loader-into-EFI-System-Partition this way.
-	# Trailing / is important in the -b argument because boot is actually
-	# a symlink.
-	installboot -m -b /${bootfs}/boot/ /${bootfs}/boot/pmbr \
-		    /${bootfs}/boot/gptzfsboot \
-		    /dev/rdsk/${a}${suffix} > /dev/null 2>&1 || \
-	    eecho "WARNING: Can't installboot on ${a}${suffix}"
-	if [[ $? -eq 0 ]]; then
-	    some=1
+	some=0
+	for a in "${boot_devices[@]}"; do
+		# Plow through devices, even if some fail.  installboot also
+		# does loader-into-EFI-System-Partition this way.  Trailing /
+		# is important in the -b argument because boot is actually a
+		# symlink.
+		installboot -m -b /${bootfs}/boot/ /${bootfs}/boot/pmbr \
+			/${bootfs}/boot/gptzfsboot \
+			/dev/rdsk/${a}${suffix} > /dev/null 2>&1 || \
+			eecho "WARNING: Can't installboot on ${a}${suffix}"
+		if [[ $? -eq 0 ]]; then
+			some=1
+		fi
+	done
+	if [[ $some -eq 0 ]]; then
+		fatal "Could not installboot(1M) on ANY vdevs of pool $2"
 	fi
-    done
-    if [[ $some -eq 0 ]]; then
-	fatal "Could not installboot(1M) on ANY vdevs of pool $2"
-    fi
-
 }
 
 activate() {
-    pistamp=$1
-    piname_present_get_bootfs $pistamp $2
-    pool=$(echo $bootfs | awk -F/ '{print $1}')
+	pistamp=$1
+	piname_present_get_bootfs $pistamp $2
+	pool=$(echo $bootfs | awk -F/ '{print $1}')
 
-    cd /$bootfs
-    if [[ -d platform-$pistamp ]]; then
-	if [[ -f platform/etc/version/platform ]]; then
-	    bootstamp=$(cat platform/etc/version/platform)
+	cd /$bootfs
+	if [[ -d platform-$pistamp ]]; then
+		if [[ -f platform/etc/version/platform ]]; then
+			bootstamp=$(cat platform/etc/version/platform)
+		else
+			bootstamp=""
+		fi
+		if [[ $bootstamp == $pistamp ]]; then
+			vecho "NOTE: $pistamp is the current active PI."
+			return
+		fi
 	else
-	    bootstamp=""
+		eecho "$pistamp is not a stamp for a PI on pool $pool"
+		usage
 	fi
-	if [[ $bootstamp == $pistamp ]]; then
-	    vecho "NOTE: $pistamp is the current active PI."
-	    return
+
+	vecho "Platform Image $pistamp will be loaded on next boot,"
+
+	# Okay, at this point we have the platform sorted out.  Let's see if
+	# we can do the same with the boot.
+	if [[ -d boot-$pistamp ]]; then
+		rm -f boot
+		ln -s ./boot-$pistamp boot
+		mkdir -p etc/version
+		echo $pistamp > etc/version/boot
+		update_boot_sectors $pool $bootfs
+		grep -q 'fstype="ufs"' ./boot/loader.conf
+		if [[ $? -ne 0 ]]; then
+			# Fix the loader.conf for keep-the-ramdisk booting.
+			echo 'fstype="ufs"' >> ./boot/loader.conf
+		fi
+		vecho "    with a new boot image,"
+	else
+		vecho "	   WARNING: $pistamp has no matching boot image, using"
+		if [[ ! -f etc/version/boot ]]; then
+			fatal "No boot version available on /$bootfs"
+		elif [[ ! -d boot/. ]]; then
+			fatal "No boot bits directory on /$bootfs"
+		fi
 	fi
-    else
-	eecho "$pistamp is not a stamp for a PI on pool $pool"
-	usage
-    fi
 
-    vecho "Platform Image $pistamp will be loaded on next boot,"
+	vecho "    boot image " $(cat etc/version/boot)
 
-    # Okay, at this point we have the platform sorted out.  Let's see
-    # if we can do the same with the boot.
-    if [[ -d boot-$pistamp ]]; then
-	rm -f boot
-	ln -s ./boot-$pistamp boot
-	mkdir -p etc/version
-	echo $pistamp > etc/version/boot
-	update_boot_sectors $pool $bootfs
-	grep -q 'fstype="ufs"' ./boot/loader.conf
-	if [[ $? -ne 0 ]]; then
-	    # Fix the loader.conf for keep-the-ramdisk booting.
-	    echo 'fstype="ufs"' >> ./boot/loader.conf
-	fi
-	vecho "	   with a new boot image,"
-    else
-	vecho "	   WARNING:  $pistamp has no matching boot image, using"
-	if [[ ! -f etc/version/boot ]]; then
-	    fatal "No boot version available on /$bootfs"
-	elif [[ ! -d boot/. ]]; then
-	    fatal "No boot bits directory on /$bootfs"
-	fi
-    fi
-
-    vecho "    boot image " $(cat etc/version/boot)
-
-    rm -f platform
-    ln -s ./platform-$pistamp platform
+	rm -f platform
+	ln -s ./platform-$pistamp platform
 }
 
 remove() {
-    pistamp=$1
-    piname_present_get_bootfs $pistamp $2
-    cd /$bootfs
-    bootstamp=$(cat platform/etc/version/platform)
+	pistamp=$1
+	piname_present_get_bootfs $pistamp $2
+	cd /$bootfs
+	bootstamp=$(cat platform/etc/version/platform)
 
-    if [[ -d platform-$pistamp ]]; then
-	if [[ $bootstamp == $pistamp ]]; then
-	    eecho "$pistamp is the next-booting PI. Please activate another PI"
-	    eecho "using 'piadm activate <other-PI-stamp>' first."
-	    usage
-	fi
+	if [[ -d platform-$pistamp ]]; then
+		if [[ $bootstamp == $pistamp ]]; then
+			eecho "$pistamp is the next-booting PI." \
+		    		"Please activate another PI"
+			eecho "using 'piadm activate <other-PI-stamp>' first."
+			usage
+		fi
 
-	# Boot image processing.
-	if [[ -d boot-$pistamp ]]; then
-	    # Boot bits may be older than the current PI, and the current PI
-	    # may not have matching boot bits for some reason.	Guard against
-	    # shooting yourself in the foot.
-	    grep -q $pistamp etc/version/boot
-	    if [[ $? -eq 0 ]]; then
-		# Oh no, pistamp points to the current boot bits.
-		eecho "$pistamp is the current set of boot binaries.  Please"
-		eecho "activate another pi using 'piadm activate <other-PI-stamp>' first."
+		# Boot image processing.
+		if [[ -d boot-$pistamp ]]; then
+			# Boot bits may be older than the current PI, and the
+			# current PI may not have matching boot bits for some
+			# reason. Guard against shooting yourself in the foot.
+			grep -q $pistamp etc/version/boot
+			if [[ $? -eq 0 ]]; then
+				eecho "$pistamp is the current set of boot" \
+					"binaries.  Please"
+				eecho "activate another pi using" \
+					"'piadm activate <other-PI-stamp>'" \
+					"first."
+				usage
+			fi
+			/bin/rm -rf boot-$pistamp
+		fi
+
+		/bin/rm -rf platform-$pistamp
+	else
+		eecho "$pistamp is not a stamp for a PI on pool $pool"
 		usage
-	    fi
-	    /bin/rm -rf boot-$pistamp
 	fi
-
-	/bin/rm -rf platform-$pistamp
-    else
-	eecho "$pistamp is not a stamp for a PI on pool $pool"
-	usage
-    fi
 }
 
 ispoolenabled() {
-    pool=$1
-    poolpresent $pool
+	pool=$1
+	poolpresent $pool
 
-    # SmartOS convention is $POOL/boot.
-    currbootfs=$(zpool get -H bootfs $pool | awk '{print $3}')
-    if [[ "$currbootfs" == "${pool}/boot" ]]; then
-	output=$(zfs list -H $currbootfs 2>&1)
-	if [[ $? -eq 0 ]]; then
-	    # We're bootable (at least bootable enough)
-	    return 0
+	# SmartOS convention is $POOL/boot.
+	currbootfs=$(zpool list -Ho bootfs $pool)
+	if [[ "$currbootfs" == "${pool}/boot" ]]; then
+		output=$(zfs list -H $currbootfs 2>&1)
+		if [[ $? -eq 0 ]]; then
+			# We're bootable (at least bootable enough)
+			return 0
+		fi
+		# else drop out to not-bootable, but this shouldn't happen.
+		vecho ".... odd, ${pool}/boot is pool's bootfs," \
+			"but isn't a filesystem"
+	elif [[ "$currbootfs" != "-" ]]; then
+		eecho "It appears pool $pool has a different boot filesystem" \
+			"than the"
+		eecho "standard SmartOS filesystem of ${pool}/boot. It will" \
+			"need manual"
+		corrupt "intervention."
 	fi
-	# else drop out to not-bootable, but honestly this shouldn't happen.
-	vecho ".... odd, ${pool}/boot is pool's bootfs, but isn't a filesystem"
-    elif [[ "$currbootfs" != "-" ]]; then
-	eecho "It appears pool $pool has a different boot filesystem than the"
-	eecho "standard SmartOS filesystem of ${pool}/boot. It will need manual"
-	corrupt "intervention."
-    fi
 
-    # Not bootable.
-    return 1
+	# Not bootable.
+	return 1
 }
 
 enablepool() {
-    if [[ $1 == "-i" ]]; then
-	if [[ "$2" == "" || "$3" == "" ]]; then
-	    eecho "-i must take an option, and then a pool must be specified."
-	    usage
+	if [[ $1 == "-i" ]]; then
+		if [[ "$2" == "" || "$3" == "" ]]; then
+			eecho "-i must take an option," \
+				"and then a pool must be specified."
+			usage
+		fi
+		installsource=$2
+		pool=$3
+	elif [[ -z $1 ]]; then
+		eecho "To enable a pool for booting, please specify at least" \
+			"a pool"
+		usage
+	else
+		installsource="media"
+		pool=$1
 	fi
-	installsource=$2
-	pool=$3
-    elif [[ -z $1 ]]; then
-	eecho "To enable a pool for booting, please specify at least a pool"
-	usage
-    else
-	installsource="media"
-	pool=$1
-    fi
 
-    bootfs=${pool}/boot
+	bootfs=${pool}/boot
 
-    ispoolenabled $pool
-    if [[ $? -eq 0 ]]; then
-	if [[ -d /${bootfs}/platform/. && -d /${bootfs}/boot/. ]]; then
-	    vecho "Pool $pool appears to be bootable."
-	    vecho "Use 'piadm install' or 'piadm activate' to change PIs."
-	    return 0
+	ispoolenabled $pool
+	if [[ $? -eq 0 ]]; then
+		if [[ -d /${bootfs}/platform/. && -d /${bootfs}/boot/. ]]; then
+			vecho "Pool $pool appears to be bootable."
+			vecho "Use 'piadm install' or 'piadm activate' to" \
+				"change PIs."
+			return 0
+		fi
+		# One or both of "platform" or "boot" aren't there.
+		# For now, proceed clobber-style.
 	fi
-	# One or both of "platform" or "boot" aren't there.
-	# For now, proceed clobber-style.
-    fi
 
-    output=$(zfs list -H $bootfs 2>&1)
-    if [[ $? -ne 0 ]]; then
-	# Create a new bootfs and set it.
-	# NOTE:	 Encryption should be turned off for this dataset.
-	zfs create -o encryption=off $bootfs
+	output=$(zfs list -H $bootfs 2>&1)
 	if [[ $? -ne 0 ]]; then
-	    fatal "Cannot create $bootfs dataset"
+		# Create a new bootfs and set it.
+		# NOTE:	 Encryption should be turned off for this dataset.
+		zfs create -o encryption=off $bootfs
+		if [[ $? -ne 0 ]]; then
+			fatal "Cannot create $bootfs dataset"
+		fi
 	fi
-    fi
-    # We MAY need to do some reality checking if the `zfs list` shows
-    # $bootfs.	For now, just wing it. and plow forward.
+	# We MAY need to do some reality checking if the `zfs list` shows
+	# $bootfs. For now, just wing it. and plow forward.
 
-    # At this point we have an existing SmartOS-standard boot
-    # filesystem, but it's not specified as bootfs in the pool.
-    # Test if bootfs can be set...
-    zpool set bootfs=${bootfs} ${pool}
-    if [[ $? -ne 0 ]]; then
-	fatal "Cannot set bootfs for $pool"
-    fi
-    # Reset our view of available bootable pools.
-    getbootable
+	# At this point we have an existing SmartOS-standard boot filesystem,
+	# but it's not specified as bootfs in the pool.  Test if bootfs can be
+	# set...
+	zpool set bootfs=${bootfs} ${pool}
+	if [[ $? -ne 0 ]]; then
+		fatal "Cannot set bootfs for $pool"
+	fi
+	# Reset our view of available bootable pools.
+	getbootable
 
-    install $installsource $pool
+	install $installsource $pool
 
-    # install set 'installstamp' on our behalf.
-    activate $installstamp $pool
+	# install set 'installstamp' on our behalf.
+	activate $installstamp $pool
 }
 
 refreshpool() {
-    pool=$1
+	pool=$1
 
-    if [[ -z $pool ]]; then
-	eecho "Must specify a pool for refresh"
-	usage
-    fi
+	if [[ -z $pool ]]; then
+		eecho "Must specify a pool for refresh"
+		usage
+	fi
 
-    currbootfs=""
-    # ispoolenabled sets currbootfs as a side-effect.
-    ispoolenabled $pool
-    if [[ $? -ne 0 ]]; then
-	err "Pool $pool is not bootable, and cannot be refreshed"
-    fi
+	currbootfs=""
+	# ispoolenabled sets currbootfs as a side-effect.
+	ispoolenabled $pool
+	if [[ $? -ne 0 ]]; then
+		err "Pool $pool is not bootable, and cannot be refreshed"
+	fi
 
-    update_boot_sectors $pool $currbootfs
+	update_boot_sectors $pool $currbootfs
 
-    return 0
+	return 0
 }
 
 bootable() {
-    if [[ "$1" == "-d" ]]; then
-	if [[ "$2" == "" ]]; then
-	    eecho "To disable a pool for booting, please specify a pool."
-	    usage
-	fi
-
-	# Reality check for bad pool name.
-	poolpresent $2
-	# Reality check for REALLY messed-up bootfs...
-	ispoolenabled $2
-
-	# Eventually we may need to do more complicated things like wipe
-	# the boot sectors clean or some other such cleanup.
-	# For now, disabling is merely unsetting `bootfs` in the pool.
-	zpool set bootfs="" $2
-	
-	return
-    elif [[ "$1" == "-e" ]]; then
-	shift 1
-	enablepool $@
-	return
-    elif [[ "$1" == "-r" ]]; then
-	refreshpool $2
-	return
-    fi
-
-    # If we reach here, we're querying about a pool.
-
-    if [[ "$1" == "" ]]; then
-	allpools=$(zpool list -H | awk '{print $1}')
-    else
-	# Reality check for bad pool name.
-	poolpresent $1
-	# Or have a list of one pool...
-	allpools=$1
-    fi
-
-    # We're guaranteed that, modulo background processes, $allpools has a list
-    # of actual pools, even if it's a list-of-one.
-
-    for pool in $allpools; do
-	zpool get -H bootfs $pool | grep -vw default | grep -q ${pool}/boot
-	if [[ $? -eq 0 ]]; then
-	    bootable="BIOS"
-	    # Check for pcfs partition on pool disks.
-	    mapfile -t boot_devices < <(zpool list -v "${pool}" | \
-					    grep -E 'c[0-9]+' | awk '{print $1}')
-	    for a in "${boot_devices[@]}"; do
-		noslice=$(echo $a | sed -E 's/s[0-9]+//g')
-		tdir=$(mktemp -d)
-		# Assume that s0 on the physical disk would be where the EFI
-		# System Partition (ESP) lives.	 A pcfs mount, ALONG WITH a
-		# check for a bootx64.efi executable, can confirm/deny it. Do
-		# this instead of just checking for bootsize because we can
-		# further integrity-check here if need be.
-		mount -F pcfs /dev/dsk/${noslice}s0 $tdir > /dev/null 2>&1
-		if [[ $? -eq 0 && -f $tdir/EFI/Boot/bootx64.efi ]]; then
-		    efi="and UEFI"
-		    umount $tdir
-		else
-		    efi=""
+	if [[ "$1" == "-d" ]]; then
+		if [[ "$2" == "" ]]; then
+			eecho "To disable a pool for booting, please specify" \
+				"a pool."
+			usage
 		fi
-		rmdir $tdir
-	    done
-	else
-	    bootable="non-bootable"
-	    efi=""
-	fi
+
+		# Reality check for bad pool name.
+		poolpresent $2
+		# Reality check for REALLY messed-up bootfs...
+		ispoolenabled $2
+
+		# Eventually we may need to do more complicated things like
+		# wipe the boot sectors clean or some other such cleanup.  For
+		# now, disabling is merely unsetting `bootfs` in the pool.
+		zpool set bootfs="" $2
 	
-	printf "%-30s ==> %s %s\n" "$pool" "$bootable" "$efi"
-    done
+		return
+	elif [[ "$1" == "-e" ]]; then
+		shift 1
+		enablepool $@
+		return
+	elif [[ "$1" == "-r" ]]; then
+		refreshpool $2
+		return
+	fi
+
+	# If we reach here, we're querying about a pool.
+
+	if [[ "$1" == "" ]]; then
+		allpools=$(zpool list -Ho name)
+	else
+		# Reality check for bad pool name.
+		poolpresent $1
+		# Or have a list of one pool...
+		allpools=$1
+	fi
+
+	# We're guaranteed that, modulo background processes, $allpools has a
+	# list of actual pools, even if it's a list-of-one.
+
+	for pool in $allpools; do
+		zpool list -Ho bootfs $pool | grep -q ${pool}/boot
+		if [[ $? -eq 0 ]]; then
+			bootable="BIOS"
+			# Check for pcfs partition on pool disks.
+			mapfile -t boot_devices < \
+				<(zpool list -vHP "${pool}" | \
+				grep -E 'c[0-9]+' | awk '{print $1}')
+			for a in "${boot_devices[@]}"; do
+				noslice=$(echo $a | sed -E 's/s[0-9]+//g')
+				tdir=$(mktemp -d)
+				# Assume that s0 on the physical disk would be
+				# where the EFI System Partition (ESP) lives.
+				# A pcfs mount, ALONG WITH a check for a
+				# bootx64.efi executable, can confirm/deny
+				# it. Do this instead of just checking for
+				# bootsize because we can further
+				# integrity-check here if need be.
+				mount -F pcfs /dev/dsk/${noslice}s0 $tdir \
+					> /dev/null 2>&1
+				if [[ $? -eq 0 && \
+					-f $tdir/EFI/Boot/bootx64.efi ]]; then
+					efi="and UEFI"
+					umount $tdir
+				else
+					efi=""
+				fi
+				rmdir $tdir
+			done
+		else
+			bootable="non-bootable"
+			efi=""
+		fi
+			   
+		printf "%-30s ==> %s %s\n" "$pool" "$bootable" "$efi"
+	done
 }
 
 if [[ "$1" == "-v" ]]; then
-    VERBOSE=1
-    shift 1
+	VERBOSE=1
+	shift 1
 elif [[ "$1" == "-vv" ]]; then
-    set -x
-    VERBOSE=1
-    shift 1
+	set -x
+	VERBOSE=1
+	shift 1
 else
-    VERBOSE=0
+	VERBOSE=0
 fi
 
 cmd=$1
 shift 1
 
 case $cmd in
-    activate | assign )
-	activate $@
-	;;
+	activate | assign )
+		activate $@
+		;;
 
-    bootable )
-	bootable $@
-	;;
+	bootable )
+		bootable $@
+		;;
 
-    install )
-	install $@
-	;;
+	install )
+		install $@
+		;;
 
-    list )
-	list $@
-	;;
+	list )
+		list $@
+		;;
 
-    remove )
-	remove $@
-	;;
+	remove )
+		remove $@
+		;;
 
-    *)
-	usage
-	;;
+	*)
+		usage
+		;;
 
 esac
 

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -169,7 +169,7 @@ mount_installmedia() {
 
 # Install a Platform Image.
 #
-# XXX KEBE SAYS there is a security discussion to be had about the integrity
+# XXX WARNING - there is a security discussion to be had about the integrity
 # of the source.
 install() {
     piname_present_get_bootfs $1 $2
@@ -385,7 +385,7 @@ update_boot_sectors() {
     pool=$1
     bootfs=$2
 
-    # XXX KEBE WARNS -- illumos#12894 will allow slogs.  We will need to
+    # XXX WARNING -- illumos#12894 will allow slogs.  We will need to
     # alter the generation of boot_devices accordingly.
     # Generate the pool's boot devices now, in case we did something
     # hyper-clever for the pool.  s1 may be created, but not yet PCFS...

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -22,7 +22,7 @@ eecho() {
 }
 
 err() {
-	eecho $1
+	eecho $@
 	exit 1
 }
 
@@ -36,7 +36,7 @@ fatal() {
 }
 
 corrupt() {
-	eecho $1
+	eecho $@
 	exit 3
 }
 

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -453,7 +453,7 @@ remove() {
     if [[ -d platform-$pistamp ]]; then
 	if [[ $bootstamp == $pistamp ]]; then
 	    echo "$pistamp is the next-booting PI. Please activate another PI"
-	    echo "using    piadm activate <other-PI-stamp>    first."
+	    echo "using 'piadm activate <other-PI-stamp>' first."
 	    usage
 	fi
 
@@ -466,7 +466,7 @@ remove() {
 	    if [[ $? -eq 0 ]]; then
 		# Oh no, pistamp points to the current boot bits.
 		echo "$pistamp is the current set of boot binaries.  Please"
-		echo "activate another pi using   piadm activate <other-PI-stamp>     first."
+		echo "activate another pi using 'piadm activate <other-PI-stamp>' first."
 		usage
 	    fi
 	    /bin/rm -rf boot-$pistamp

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -68,9 +68,9 @@ getbootable() {
     numbootfs=${#allbootfs[@]}
 }
 
-declare -a activestamp
+declare activestamp
 activestamp=$(uname -v | sed 's/joyent_//g')
-declare -a installstamp
+declare installstamp
 
 poolpresent() {
     # Works for an empty $1, which is "all of them" or "unspecified"

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -69,8 +69,12 @@ piname_present_get_bootfs() {
     if [[ $numbootable -ne 1 && "$2" == "" ]]; then
 	echo "Multiple bootable pools are available, please specify one"
 	usage
-    elif [[ $numbootable -eq 1 ]]; then
+    elif [[ $numbootable -le 1 ]]; then
 	bootfs=$allbootable
+	if [[ "$bootfs" == "" ]]; then
+	    echo "No bootable pools available..."
+	    usage
+	fi
 	pool=$(echo $bootfs | awk -F/ '{print $1}')
     else
 	pool=$2
@@ -216,7 +220,7 @@ list() {
 
 activate() {
     pistamp=$1
-    bootfs=`piname_present_get_bootfs $1 $2`
+    bootfs=`piname_present_get_bootfs $pistamp $2`
 
     cd /$bootfs
     bootstamp=$(file -h platform | awk '{print $5}' | sed 's/\.\/platform-//g')

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -451,12 +451,12 @@ activate() {
 	    # Fix the loader.conf for keep-the-ramdisk booting.
 	    echo 'fstype="ufs"' >> ./boot/loader.conf
 	fi
-	echo "    with a new boot image,"
+	vecho "    with a new boot image,"
     else
-	echo "    WARNING:  $pistamp has no matching boot image, using"
+	vecho "    WARNING:  $pistamp has no matching boot image, using"
     fi
 
-    echo "    boot image " `cat etc/version/boot`
+    vecho "    boot image " `cat etc/version/boot`
 
     rm -f platform
     ln -s ./platform-$pistamp platform

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -343,9 +343,11 @@ install() {
     fi
     /bin/rm -rf ${tdir}
 
-    if [[ ! -d /${bootfs}/platform-${stamp} || ! -d /${bootfs}/boot-${stamp} ]]
-    then
-	fatal "Installation problem"
+    if [[ ! -d /${bootfs}/platform-${stamp} ]]; then
+	fatal "Installation problem (no ${bootfs}/platform-${stamp})"
+    fi
+    if [[ ! -d /${bootfs}/boot-${stamp} && "$iso" == "yes" ]]; then
+	fatal "Installation problem (no ${bootfs}/boot-${stamp} from ISO)"
     fi
 
     # Global variable for enablepool() usage...

--- a/src/smartdc/lib/smartos_prompt_config.sh
+++ b/src/smartdc/lib/smartos_prompt_config.sh
@@ -1051,7 +1051,7 @@ copy_installmedia()
 	fi
 
 	# Move it all over!
-	tar -cf - -C /mnt . | tar -xf - -C /${SYS_ZPOOL}/boot
+	tar -cf - -C /mnt . | tar -xf - -C /${BOOTPOOL}/boot
 	if [[ $? != 0 ]]; then
 		fatal "Cannot move install media bits to bootable disk"
 	fi
@@ -1063,9 +1063,9 @@ copy_installmedia()
 	fi
 
 	# Extract the PI stamp for the platform and symlinks.
-	pistamp=`cat /${SYS_ZPOOL}/boot/platform/etc/version/platform`
-	mv /${SYS_ZPOOL}/boot/platform /${SYS_ZPOOL}/boot/platform-${pistamp}
-	ln -s ./platform-${pistamp} /${SYS_ZPOOL}/boot/platform
+	pistamp=`cat /${BOOTPOOL}/boot/platform/etc/version/platform`
+	mv /${BOOTPOOL}/boot/platform /${BOOTPOOL}/boot/platform-${pistamp}
+	ln -s ./platform-${pistamp} /${BOOTPOOL}/boot/platform
 }
 
 trap "" SIGINT

--- a/src/smartdc/lib/smartos_prompt_config.sh
+++ b/src/smartdc/lib/smartos_prompt_config.sh
@@ -1041,7 +1041,7 @@ create_zpools()
 copy_installmedia()
 {
 	# Try the USB key first, quietly...
-	mount_usb_key /mnt 2>&1 > /dev/null
+	mount_usb_key /mnt > /dev/null 2>&1 
 	if [[ $? != 0 ]]; then
 	    # If that fails, try mounting the ISO.
 	    mount_ISO /mnt || fatal "Odd, can't find install media!"
@@ -1445,6 +1445,11 @@ if [ $ondisk == "yes" ]; then
 	# Get "install media mounted" and copy over boot stuff:
 	copy_installmedia
 
+	# Append 'fstype="ufs"' to /${BOOTPOOL}/boot/boot/loader.conf for
+	# ramdisk root.
+	echo 'fstype="ufs"' >> /${BOOTPOOL}/boot/boot/loader.conf || \
+	    fatal "Can't append to /${BOOTPOOL}/boot/boot/loader.conf"
+
 	# XXX KEBE SAYS Determine which disk(s) to install things in.
 	# Then for each disk:
 	# 	installboot -m -b....
@@ -1457,14 +1462,9 @@ if [ $ondisk == "yes" ]; then
 	    installboot -m -b /${BOOTPOOL}/boot/boot \
 	    /${BOOTPOOL}/boot/boot/pmbr \
 	    /${BOOTPOOL}/boot/boot/gptzfsboot \
-	    /dev/rdsk/${a}s1 2>&1 > /dev/null || \
+	    /dev/rdsk/${a}s1 > /dev/null 2>&1 || \
 		fatal "Can't install boot sector and/or UEFI loader, $a."
 	done
-
-	# Append 'fstype="ufs"' to /${BOOTPOOL}/boot/boot/loader.conf for
-	# ramdisk root.
-	echo 'fstype="ufs"' >> /${BOOTPOOL}/boot/boot/loader.conf || \
-	    fatal "Can't append to /${BOOTPOOL}/boot/boot/loader.conf"
 
 	printf "%4s\n" done
     fi

--- a/src/smartdc/lib/smartos_prompt_config.sh
+++ b/src/smartdc/lib/smartos_prompt_config.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Copyright 2019 Joyent, Inc.
+# Copyright 2020 Joyent, Inc.
 #
 
 # XXX - TODO
@@ -1066,6 +1066,15 @@ copy_installmedia()
 	pistamp=`cat /${BOOTPOOL}/boot/platform/etc/version/platform`
 	mv /${BOOTPOOL}/boot/platform /${BOOTPOOL}/boot/platform-${pistamp}
 	ln -s ./platform-${pistamp} /${BOOTPOOL}/boot/platform
+	#
+	# The idea is that a new PI can be booted by doing the following:
+	# - Unpack the platform-YYYYMMDDhhmmssZ.tgz PI into
+	#   $BOOTPOOL/boot/platform-YYYYMMDDhhmmssZ/.
+	# - Remove the "platform" symlink.
+	# - Re-add the "platform" symlink to point to the new
+	#   platform-YYYYMMDDhhmmssZ/ directory.
+	# - Next boot will extract "platform" from the new YYYYMMDDhhmmssZ
+	#
 }
 
 trap "" SIGINT
@@ -1453,13 +1462,13 @@ if [ $ondisk == "yes" ]; then
 	echo 'fstype="ufs"' >> /${BOOTPOOL}/boot/boot/loader.conf || \
 	    fatal "Can't append to /${BOOTPOOL}/boot/boot/loader.conf"
 
-	# XXX KEBE SAYS Determine which disk(s) to install things in.
+	# Determine which disk(s) to install things in.
 	# Then for each disk:
 	# 	installboot -m -b....
-	# <SNIP!>
-	# XXX KEBE SCREAMS This is a cheesy workaround:
-	# - Takes first disk only, regardless
-	# - Assumes `zpool create -B` has s0 == ESP, s1 == data-for-BOOTPOOL
+	#
+	# We created the pool, so we can assume
+	# `zpool create -B` generates things such that for disk X, Xs0 == ESP,
+	# Xs1 == data-for-BOOTPOOL
 	for a in \
 	`zpool list -v ${BOOTPOOL} | egrep 'c[0-9]+' | awk '{print $1}'`; do
 	    installboot -m -b /${BOOTPOOL}/boot/boot \

--- a/src/smartdc/lib/smartos_prompt_config.sh
+++ b/src/smartdc/lib/smartos_prompt_config.sh
@@ -1298,7 +1298,7 @@ your own zpool.\n"
 	promptpool
 
 	# Set value for BOOTPOOL now.  Use "standalone" if the user
-	# created it manually.
+	# created it manually up on promptpool.
 	zpool list standalone >/dev/null 2>/dev/null
 	if [[ $? -eq 0 ]]; then
 		BOOTPOOL="standalone"
@@ -1362,9 +1362,6 @@ up and all data on the disks will be erased.\n\n"
 		printf "Hostname: %s\n" "$hostname"
 		printf "NTP server: $ntp_hosts\n"
 		if [[ $ondisk == "yes" ]]; then
-		    if [[ -z "$BOOTPOOL" ]]; then
-			BOOTPOOL=$SYS_ZPOOL
-		    fi
 		    printf "==> Making the $BOOTPOOL pool bootable"
 		fi
 		echo

--- a/src/smartdc/lib/smartos_prompt_config.sh
+++ b/src/smartdc/lib/smartos_prompt_config.sh
@@ -1450,7 +1450,8 @@ if [ $boot_non_removable == "yes" ]; then
     fi
 
     # Create BOOTPOOL/boot and set bootfs.
-    zfs create ${BOOTPOOL}/boot || fatal "Cannot create boot filesystem"
+    zfs create -o encryption=off ${BOOTPOOL}/boot || \
+	fatal "Cannot create boot filesystem"
     zpool set bootfs=${BOOTPOOL}/boot ${BOOTPOOL}
     if [[ $? -ne 0 ]]; then
 	fatal "\nCannot set bootfs"
@@ -1470,8 +1471,9 @@ if [ $boot_non_removable == "yes" ]; then
 	# We created the pool, so we can assume
 	# `zpool create -B` generates things such that for disk X, Xs0 == ESP,
 	# Xs1 == data-for-BOOTPOOL
-	for a in \
-	`zpool list -v ${BOOTPOOL} | egrep 'c[0-9]+' | awk '{print $1}'`; do
+	mapfile -t boot_devices < <(zpool list -v "${BOOTPOOL}" | \
+		grep -E 'c[0-9]+' | awk '{print $1}')
+	for a in "${boot_devices[@]}"; do
 	    installboot -m -b /${BOOTPOOL}/boot/boot \
 	    /${BOOTPOOL}/boot/boot/pmbr \
 	    /${BOOTPOOL}/boot/boot/gptzfsboot \

--- a/src/smartdc/lib/smartos_prompt_config.sh
+++ b/src/smartdc/lib/smartos_prompt_config.sh
@@ -852,12 +852,6 @@ EOF
 			echo "to \"zones\" if you wish to boot from disks that are"
 			echo "not part of the \"zones\" zpool."
 			/usr/bin/bash
-			zpool list standalone >/dev/null 2>/dev/null
-			if [[ $? -eq 0 ]]; then
-				BOOTPOOL="standalone"
-			else
-				BOOTPOOL="zones"
-			fi
 			zpool list zones >/dev/null 2>/dev/null
 			[[ $? -eq 0 ]] && return
 		else
@@ -1302,6 +1296,15 @@ your own zpool.\n"
 	fi
 
 	promptpool
+
+	# Set value for BOOTPOOL now.  Use "standalone" if the user
+	# created it manually.
+	zpool list standalone >/dev/null 2>/dev/null
+	if [[ $? -eq 0 ]]; then
+		BOOTPOOL="standalone"
+	else
+		BOOTPOOL="zones"
+	fi
 
 	printheader "Self-booting"
 

--- a/src/smartdc/lib/smartos_prompt_config.sh
+++ b/src/smartdc/lib/smartos_prompt_config.sh
@@ -1435,7 +1435,7 @@ if [ $ondisk == "yes" ]; then
     # Easiest way to do this is to check for the `bootsize` property not
     # its default, which is NO bootsize.
     zpool get bootsize ${BOOTPOOL} | grep -q -w default
-    if [[ $? == 0 ]];
+    if [[ $? == 0 ]]; then
 	fatal "\nDesired bootable pool $BOOTPOOL was not created with -B"
     fi
 

--- a/src/smartdc/lib/smartos_prompt_config.sh
+++ b/src/smartdc/lib/smartos_prompt_config.sh
@@ -1047,7 +1047,7 @@ copy_installmedia()
 	fi
 
 	# Move it all over!
-	tar -cf - -C /mnt . | tar -xf - -C /zones/boot
+	tar -cf - -C /mnt . | tar -xf - -C /${SYS_ZPOOL}/boot
 	if [[ $? != 0 ]]; then
 		fatal "Cannot move install media bits to bootable disk"
 	fi
@@ -1059,9 +1059,9 @@ copy_installmedia()
 	fi
 
 	# Extract the PI stamp for the platform and symlinks.
-	pistamp=`cat /zones/boot/platform/etc/version/platform`
-	mv /zones/boot/platform /zones/boot/platform-${pistamp}
-	ln -s ./platform-${pistamp} /zones/boot/platform
+	pistamp=`cat /${SYS_ZPOOL}/boot/platform/etc/version/platform`
+	mv /${SYS_ZPOOL}/boot/platform /${SYS_ZPOOL}/boot/platform-${pistamp}
+	ln -s ./platform-${pistamp} /${SYS_ZPOOL}/boot/platform
 }
 
 trap "" SIGINT
@@ -1440,15 +1440,17 @@ if [ $ondisk == "yes" ]; then
 	# - Assumes `zpool create -B` has s0 == ESP, s1 == data-for-SYS_ZPOOL
 	for a in \
 	`zpool list -v ${SYS_ZPOOL} | egrep 'c[0-9]+' | awk '{print $1}'`; do
-	    installboot -m -b /zones/boot/boot /zones/boot/boot/pmbr \
-	    /zones/boot/boot/gptzfsboot /dev/rdsk/${a}s1 2>&1 > /dev/null || \
+	    installboot -m -b /${SYS_ZPOOL}/boot/boot \
+	    /${SYS_ZPOOL}/boot/boot/pmbr \
+	    /${SYS_ZPOOL}/boot/boot/gptzfsboot \
+	    /dev/rdsk/${a}s1 2>&1 > /dev/null || \
 		fatal "Can't install boot sector and/or UEFI loader, $a."
 	done
 
-	# Append 'fstype="ufs"' to /zones/boot/boot/loader.conf for
+	# Append 'fstype="ufs"' to /${SYS_ZPOOL}/boot/boot/loader.conf for
 	# ramdisk root.
-	echo 'fstype="ufs"' >> /zones/boot/boot/loader.conf || \
-	    fatal "Can't append to /zones/boot/boot/loader.conf"
+	echo 'fstype="ufs"' >> /${SYS_ZPOOL}/boot/boot/loader.conf || \
+	    fatal "Can't append to /${SYS_ZPOOL}/boot/boot/loader.conf"
 
 	printf "%4s\n" done
     fi

--- a/src/smartdc/lib/smartos_prompt_config.sh
+++ b/src/smartdc/lib/smartos_prompt_config.sh
@@ -1307,7 +1307,8 @@ your own zpool.\n"
 	promptpool
 
 	# Set value for BOOTPOOL now.  Use "standalone" if the user
-	# created it manually up on promptpool.
+	# created it manually during the promptpool function a few
+	# lines earlier.
 	zpool list standalone >/dev/null 2>/dev/null
 	if [[ $? -eq 0 ]]; then
 		BOOTPOOL="standalone"

--- a/src/smartdc/lib/smartos_prompt_config.sh
+++ b/src/smartdc/lib/smartos_prompt_config.sh
@@ -1040,8 +1040,8 @@ create_zpools()
 
 copy_installmedia()
 {
-	# Try the USB key first...
-	mount_usb_key /mnt
+	# Try the USB key first, quietly...
+	mount_usb_key /mnt 2>&1 > /dev/null
 	if [[ $? != 0 ]]; then
 	    # If that fails, try mounting the ISO.
 	    mount_ISO /mnt || fatal "Odd, can't find install media!"

--- a/src/smartdc/lib/smartos_prompt_config.sh
+++ b/src/smartdc/lib/smartos_prompt_config.sh
@@ -1294,8 +1294,10 @@ make a SmartOS zpool self-booting.\n"
 
 	promptyesno "Boot SmartOS from a zpool" $boot_from_zpool
 	boot_from_zpool="$val"
-	promptval "Bootable pool's name" $BOOTPOOL
-	BOOTPOOL=$val
+	if [[ "$boot_from_zpool" == "yes" ]]; then
+	    promptval "Bootable pool's name" $BOOTPOOL
+	    BOOTPOOL=$val
+	fi
 
 	printheader "System Configuration"
 	message="

--- a/src/smartdc/lib/smartos_prompt_config.sh
+++ b/src/smartdc/lib/smartos_prompt_config.sh
@@ -996,12 +996,18 @@ create_zpool()
 
 	# If this is not a manual layout, then we've been given
 	# a JSON file describing the desired pool, so use that:
-	# Try and make a bootable one first.
-	mkzpool -B -f $pool $layout
-	if [[ $? -ne 0 ]]; then
-	    boot_non_removable="never"
-	    printf "\n\t%-56s\n" \
-		"$pool cannot be bootable, creating non-bootable..."
+	# Try and make a bootable one if so desired.
+	if [[ $boot_non_removable == "yes" && $BOOTPOOL == $pool ]]; then
+	    mkzpool -B -f $pool $layout
+	    if [[ $? -ne 0 ]]; then
+		# reset boot_non_removable so we proceed w/o a bootable pool.
+		boot_non_removable="never"
+		printf "\n\t%-56s\n" \
+		       "$pool cannot be bootable, creating non-bootable..."
+	    fi
+	fi
+	# User didn't specify bootable pool OR we have a standalone boot pool.
+	if [[ $boot_non_removable != "yes" || $pool != $BOOTPOOL ]]; then
 	    mkzpool -f $pool $layout || fatal "failed to create pool ${pool}"
 	fi
 

--- a/src/smartdc/lib/smartos_prompt_config.sh
+++ b/src/smartdc/lib/smartos_prompt_config.sh
@@ -1255,8 +1255,9 @@ your own zpool.\n"
 
 	message="
 SmartOS can boot off either the \"zones\" zpool, or a dedicated named
-zpool in lieu of a USB stick or a CD-ROM.  Enter 'yes' if you wish to try and
-make a SmartOS zpool self-booting.\n"
+zpool in lieu of a USB stick or a CD-ROM.  Enter a pool name if you wish to
+try and make a SmartOS zpool self-booting.  Enter \"none\" to not create
+a self-booting pool.\n"
 
 	
 	if [[ $(getanswer "skip_instructions") != "true" ]]; then
@@ -1264,14 +1265,14 @@ make a SmartOS zpool self-booting.\n"
 	    echo "Available pre-created pools: " $(zpool list -Ho name)
 	fi
 
-	promptopt "Specify a (configured) zpool from which to boot" "none" \
-		"bootpool"
+	promptopt "Specify a (configured) zpool from which to boot" \
+		${BOOTPOOL-"none"} "bootpool"
 	if [[ "$val" != "none" ]]; then
 		boot_from_zpool="yes"
-		BOOTPOOL=$val
 	else
 		boot_from_zpool="no"
 	fi
+	BOOTPOOL=$val
 
 	printheader "System Configuration"
 	message="


### PR DESCRIPTION
Allow a bootable `zones` pool, OR if manual pool configuration generates a `standalone` pool, use that.  Bootable pools can be on either BIOS or UEFI.

This is a WIP.  As indicated in the installer comments, the initial thought is to have PIs live in $BOOTPOOL`/boot/platform-YYYYxxxxx/` directories, and have $BOOTPOOL`/boot/platform` symlink to the desired PI.

Needs lots more work, including better install-time mechanisms, and a tool not unlike `sdcadm platform` to deal with PIs.  (One thought I had was `piadm`(1M), which future `sdcadm platform` could use on the Head Node.)