### PR TITLE
 ignore missing mountpoint when deleting snapshots

### DIFF
--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -13439,11 +13439,11 @@ exports.delete_snapshot = function (uuid, snapname, options, callback)
                 if (e) {
                     log.error({err: e}, 'There was an error while '
                         + 'unmounting the snapshot: ' + e.message);
-                    // we treat an error here as fatal only if the error
-                    // was something other than 'not mounted'
-                    //                       or 'no such file or directory'
-                    // 'no such file or directory' occurs when the mountpoint
-                    // directory does not exist or it was never created
+                    // We treat an error here as fatal only if the error
+                    // was something other than 'not mounted' or
+                    // 'no such file or directory'.
+                    // The missing mountpoint directory is also ignored
+                    // in the next step.
                     if (!stderr.match(/ not mounted/)
                         && !stderr.match(/ no such file or directory/)) {
                         cb(e);
@@ -13467,7 +13467,7 @@ exports.delete_snapshot = function (uuid, snapname, options, callback)
                 } else {
                     log.trace('removed directory ' + mountpoint);
                 }
-                cb(); // XXX not fatal because might also not exist
+                cb(); // XXX not fatal because might also not exist, see above
             });
         }, function (cb) {
             var cancelFn;

--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -13441,7 +13441,11 @@ exports.delete_snapshot = function (uuid, snapname, options, callback)
                         + 'unmounting the snapshot: ' + e.message);
                     // we treat an error here as fatal only if the error
                     // was something other than 'not mounted'
-                    if (!stderr.match(/ not mounted/)) {
+                    //                       or 'no such file or directory'
+                    // 'no such file or directory' occurs when the mountpoint
+                    // directory does not exist or it was never created
+                    if (!stderr.match(/ not mounted/)
+                        && !stderr.match(/ no such file or directory/)) {
                         cb(e);
                         return;
                     }

--- a/src/vm/tests/test-snapshots.js
+++ b/src/vm/tests/test-snapshots.js
@@ -637,8 +637,9 @@ function createSnapshot(t, uuid, snapname, expected_count, cb) {
         VM.load(vmobj.uuid, function (e, o) {
             t.ok(!e, 'loading VM after create');
             if (!e) {
-                t.ok(o.snapshots.length === expected_count, expected_count
-                    + ' snapshot(s) after create');
+                t.ok(o.snapshots.length === expected_count, o.snapshots.length
+                    + ' snapshot(s) after create: [expected: '
+                    + expected_count + ']');
             } else {
                 abort = true;
             }
@@ -662,9 +663,8 @@ function deleteSnapshot(t, uuid, snapname, expected_remaining, cb) {
                 cb(e);
                 return;
             }
-            // snapshot3 should have been deleted since it's newer
             t.ok(o.snapshots.length === expected_remaining, o.snapshots.length
-                + ' snapshots remain after rollback: [expected: '
+                + ' snapshot(s) after delete: [expected: '
                 + expected_remaining + ']');
             cb();
         });
@@ -879,6 +879,58 @@ test('create/delete joyent-minimal snapshot should handle mounting '
     });
 });
 
+test('delete unmounted snapshot with missing checkpoint directory',
+function (t) {
+    var snapname = 'nomountdir';
+    var checkpoint_dir
+        = path.join(vmobj.zonepath, 'root', 'checkpoints', snapname);
+
+    if (abort) {
+        t.ok(false, 'skipping unmounted checkpoint tests');
+        t.end();
+        return;
+    }
+    var snapshot_count = 0;
+
+    vasync.pipeline({funcs: [
+        function (_, cb) {
+            createSnapshot(t, vmobj.uuid, snapname, ++snapshot_count,
+                function (err) {
+                    common.ifError(t, err,
+                        'created snapshot for nomountdir test');
+                    cb(err);
+                }
+            );
+        }, function (_, cb) {
+                var argv;
+                var cmd = '/usr/sbin/umount';
+                argv = [checkpoint_dir];
+                execFile(cmd, argv, function (err) {
+                    common.ifError(t, err, 'umount-ed ' + checkpoint_dir);
+                    cb(err);
+                });
+        }, function (_, cb) {
+            fs.rmdir(checkpoint_dir,
+                function (err) {
+                    common.ifError(t, err,
+                        'deleted ' + checkpoint_dir +' for nomountdir test');
+                    cb(err);
+                }
+            );
+        }, function (_, cb) {
+            deleteSnapshot(t, vmobj.uuid, snapname, --snapshot_count,
+                function (err) {
+                    common.ifError(t, err, 'deleted ' + snapname +
+                        ' snapshot for ' + vmobj.uuid);
+                    cb(err);
+                }
+            );
+        }
+    ]}, function (err) {
+        common.ifError(t, err, 'testing snapshot deletion without mountpoint');
+        t.end();
+    });
+});
 
 // create 10 snapshots (to test that deleting a VM with snapshots works)
 test('create 10 more snapshots of joyent-minimal VM', function (t) {

--- a/src/vm/tests/test-snapshots.js
+++ b/src/vm/tests/test-snapshots.js
@@ -894,7 +894,8 @@ function (t) {
 
     vasync.pipeline({funcs: [
         function (_, cb) {
-            createSnapshot(t, vmobj.uuid, snapname, ++snapshot_count,
+            snapshot_count += 1;
+            createSnapshot(t, vmobj.uuid, snapname, snapshot_count,
                 function (err) {
                     common.ifError(t, err,
                         'created snapshot for nomountdir test');
@@ -918,10 +919,11 @@ function (t) {
                 }
             );
         }, function (_, cb) {
-            deleteSnapshot(t, vmobj.uuid, snapname, --snapshot_count,
+            snapshot_count -= 1;
+            deleteSnapshot(t, vmobj.uuid, snapname, snapshot_count,
                 function (err) {
-                    common.ifError(t, err, 'deleted ' + snapname +
-                        ' snapshot for ' + vmobj.uuid);
+                    common.ifError(t, err,
+                        'deleted ' + snapname + ' snapshot for ' + vmobj.uuid);
                     cb(err);
                 }
             );


### PR DESCRIPTION
Adds a second condition to ignore when attempting to umount a snapshot before deleting it (directory does not exist).
The subsequent step already ignores a failed delete of the missing directory.

Adds a testcase to validate this scenario.

Improves test output when creating/deleting snapshots.

Fixes joyent/smartos-live#943, fixes joyent/smartos-live#480.

Output from new "nomountdir" testcase as executed on smartos 20200326T183047Z:
```
# delete unmounted snapshot with missing checkpoint directory
ok 415 creating snapshot nomountdir of 018f9c08-267c-cecb-d8b2-f10f50bca46a: success
ok 416 loading VM after create
ok 417 1 snapshot(s) after create: [expected: 1]
ok 418 created snapshot for nomountdir test: success
ok 419 umount-ed /zones/018f9c08-267c-cecb-d8b2-f10f50bca46a/root/checkpoints/nomountdir: success
ok 420 deleted /zones/018f9c08-267c-cecb-d8b2-f10f50bca46a/root/checkpoints/nomountdir for nomountdir test: success
ok 421 deleting nomountdir of 018f9c08-267c-cecb-d8b2-f10f50bca46a: success
ok 422 loading VM after delete of nomountdir
ok 423 0 snapshot(s) after delete: [expected: 0]
ok 424 deleted nomountdir snapshot for 018f9c08-267c-cecb-d8b2-f10f50bca46a: success
ok 425 testing snapshot deletion without mountpoint: success
```