### PR TITLE
OS-8204 Add "avail" subcommand to piadm(1M)

### DIFF
--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -135,7 +135,8 @@ drwxr-xr-x   4 root     root           5 Jul 15 04:12 platform-20200714T195617Z
       piadm avail
 
         Query the well-known SmartOS PI repository for available ISO images,
-        listed by PI-Stamp.
+        listed by PI-Stamp. No PI-Stamps older than ones that contain
+        piadm(1M) will be listed.
 
       piadm bootable [-d | -e [-i <source>] | -r] [ZFS-pool-name]
 

--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -135,8 +135,8 @@ drwxr-xr-x   4 root     root           5 Jul 15 04:12 platform-20200714T195617Z
       piadm avail
 
         Query the well-known SmartOS PI repository for available ISO images,
-        listed by PI-Stamp. No PI-Stamps older than ones that contain
-        piadm(1M) will be listed.
+        listed by PI-Stamp. No PI-Stamps older than the currently running PI
+        stamp will be listed.
 
       piadm bootable [-d | -e [-i <source>] | -r] [ZFS-pool-name]
 

--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -6,6 +6,7 @@ piadm(1M) -- Manage SmartOS Platform Images
     /usr/sbin/piadm [-v | -vv] <command> [command-specific arguments]
 
     piadm activate|assign <PI-stamp> [ZFS-pool-name]
+    piadm avail
     piadm bootable
     piadm bootable [-dr] <ZFS-pool-name>
     piadm bootable -e [ -i <source> ] <ZFS-pool-name>
@@ -130,6 +131,11 @@ drwxr-xr-x   4 root     root           5 Jul 15 04:12 platform-20200714T195617Z
 
         `activate` and `assign` are synonyms, for those used to other
         distros' `beadm`, or Triton's `sdcadm platform`, respectively.
+
+      piadm avail
+
+        Query the well-known SmartOS PI repository for available ISO images,
+        listed by PI-Stamp.
 
       piadm bootable [-d | -e [-i <source>] | -r] [ZFS-pool-name]
 

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -157,9 +157,8 @@ avail() {
 
 	# The aforementioned Manta method, parsed by json(1).
 	# Don't print ones old enough to NOT contain piadm(1M) itself.
-	$CURL ${URL_PREFIX}/?limit=1000 | \
-		json -ga -c 'this.name.match("Z$")' name | \
-		awk '{if ($1 > 20200825) print $1}'
+	$CURL ${URL_PREFIX}/?limit=1000 | json -ga -c \
+		'this.name.match(/Z$/) && this.name>"20200825T000000Z"' name
 }
 
 # Scan for available installation media and mount it.

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -156,8 +156,10 @@ avail() {
 	fi
 
 	# The aforementioned Manta method, parsed by json(1).
+	# Don't print ones old enough to NOT contain piadm(1M) itself.
 	$CURL ${URL_PREFIX}/?limit=1000 | \
-		json -ga -c 'this.name.match("Z$")' name
+		json -ga -c 'this.name.match("Z$")' name | \
+		awk '{if ($1 > 20200825) print $1}'
 }
 
 # Scan for available installation media and mount it.

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -158,7 +158,7 @@ avail() {
 	# The aforementioned Manta method, parsed by json(1).
 	# Don't print ones old enough to NOT contain piadm(1M) itself.
 	$CURL ${URL_PREFIX}/?limit=1000 | json -ga -c \
-		'this.name.match(/Z$/) && this.name>"20200825T000000Z"' name
+		"this.name.match(/Z$/) && this.name>=\"$activestamp\"" name
 }
 
 # Scan for available installation media and mount it.


### PR DESCRIPTION
Subject says it all.  Tested on my `smartos-bios` VM both stock (which produces a lot of output) and with a PIADM_URL_PREFIX that triggers the warning path.