### PR TITLE
OS-8205 `piadm bootable -d` needs to be more thorough

### DIFF
--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -493,7 +493,7 @@ update_boot_sectors() {
 				continue
 			fi
 			# otherwise mount the ESP and trash it.
-			tdir=`mktemp -d`
+			tdir=$(mktemp -d)
 			mount -F pcfs /dev/dsk/${a}s0 ${tdir}
 			if [[ $? -ne 0 ]]; then
 				eecho "disk $a has no PCFS ESP, it seems"


### PR DESCRIPTION
Tested thus far on a SmartOS VM with an EFI-capable `zones` pool using `bootable -d` and then checking the ESP to see that it's erased.