### PR TITLE
OS-8230 want piadm.sh to be shellcheck clean

### DIFF
--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -489,9 +489,8 @@ update_boot_sectors() {
 			fi
 			# otherwise mount the ESP and trash it.
 			tdir=$(mktemp -d)
-			if mount -F pcfs "/dev/dsk/${a}s0" "${tdir:?}" ; then
-				some=1
-			else
+			if ! mount -F pcfs "/dev/dsk/${a}s0" "${tdir:?}" ; then
+				# Wrong filesystem, so skip the rest of this loop
 				eecho "disk $a has no PCFS ESP, it seems"
 				continue
 			fi
@@ -499,6 +498,7 @@ update_boot_sectors() {
 			# is using it for something ELSE also.
 			/bin/rm -rf "${tdir}/EFI"
 			umount "$tdir" && rmdir "$tdir"
+			some=1
 			# If we make it here, at least some disks had
 			# ESP and we managed to clean them out.  "some" below
 			# will get set.
@@ -597,7 +597,7 @@ remove() {
 			# Boot bits may be older than the current PI, and the
 			# current PI may not have matching boot bits for some
 			# reason. Guard against shooting yourself in the foot.
-			if ! grep -q "$pistamp" etc/version/boot; then
+			if grep -q "$pistamp" etc/version/boot; then
 				eecho "$pistamp is the current set of boot" \
 					"binaries.  Please"
 				eecho "activate another pi using" \

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -15,14 +15,15 @@
 # Copyright 2020 Joyent, Inc.
 #
 
+# shellcheck disable=1091
 . /lib/sdc/usb-key.sh
 
 eecho() {
-	echo $@ 1>&2
+	echo "$@" 1>&2
 }
 
 err() {
-	eecho $@
+	eecho "$@"
 	exit 1
 }
 
@@ -36,7 +37,7 @@ fatal() {
 }
 
 corrupt() {
-	eecho $@
+	eecho "$@"
 	exit 3
 }
 
@@ -56,7 +57,7 @@ usage() {
 vecho() {
 	if [[ $VERBOSE -eq 1 ]]; then
 		# Verbose echoes invoked by -v go to stdout, not stderr.
-		echo $@
+		echo "$@"
 	fi
 }
 
@@ -80,8 +81,7 @@ declare installstamp
 
 poolpresent() {
 	# Works for an empty $1, which is "all of them" or "unspecified"
-	zpool list $1 > /dev/null 2>&1
-	if [[ $? -ne 0 ]]; then
+	if ! zpool list "$1" > /dev/null 2>&1 ; then
 		eecho "Pool $1 not present"
 		usage
 	fi
@@ -97,7 +97,7 @@ piname_present_get_bootfs() {
 		usage
 	fi
 
-	poolpresent $pool
+	poolpresent "$pool"
 
 	getbootable
 	if [[ $numbootfs -gt 1 && "$2" == "" ]]; then
@@ -105,12 +105,12 @@ piname_present_get_bootfs() {
 		usage
 	elif [[ "$2" == "" ]]; then
 		# If we reach here, no more than one bootable pool.
-		bootfs=$allbootfs
+		bootfs=${allbootfs[0]}
 		if [[ "$bootfs" == "" ]]; then
 			eecho "No bootable pools available..."
 			usage
 		fi
-		pool=$(echo $bootfs | awk -F/ '{print $1}')
+		pool=$(echo "$bootfs" | awk -F/ '{print $1}')
 		vecho "Selecting lone boot pool $pool by default."
 	else
 		# If we reach here, the CLI specifies a known-present (passes
@@ -118,9 +118,9 @@ piname_present_get_bootfs() {
 		# against..
 		pool=$2
 		bootfs=""
-		for check in ${allbootfs[@]}; do
-			thispool=$(echo $check | awk -F/ '{print $1}')
-			if [[ $thispool == $pool ]]; then
+		for check in "${allbootfs[@]}"; do
+			thispool=$(echo "$check" | awk -F/ '{print $1}')
+			if [[ $thispool == "$pool" ]]; then
 			    bootfs=$check
 			    break
 			fi
@@ -134,7 +134,7 @@ piname_present_get_bootfs() {
 
 # Defined as a variable in case we need to add parameters (like -s) to it.
 # WARNING:  Including -k for now.
-CURL="curl -ks"
+CURL=( curl -ks -f )
 
 # Well-known source of SmartOS Platform Images
 DEFAULT_URL_PREFIX=https://us-east.manta.joyent.com/Joyent_Dev/public/SmartOS/
@@ -157,7 +157,7 @@ avail() {
 
 	# The aforementioned Manta method, parsed by json(1).
 	# Don't print ones old enough to NOT contain piadm(1M) itself.
-	$CURL ${URL_PREFIX}/?limit=1000 | json -ga -c \
+	"${CURL[@]}" "${URL_PREFIX}/?limit=1000" | json -ga -c \
 		"this.name.match(/Z$/) && this.name>=\"$activestamp\"" name
 }
 
@@ -169,26 +169,24 @@ mount_installmedia() {
 	mntdir=$1
 
 	# Try the USB key first, quietly and without $mntdir/.joyentusb check
-	mount_usb_key $mntdir skip > $tfile 2>&1
-	if [[ $? -ne 0 ]]; then
-		# If that fails, try mounting the ISO.
-		mount_ISO $mntdir > $tfile2 2>&1
-		if [[ $? -ne 0 ]]; then
+	if ! mount_usb_key "$mntdir" skip > "$tfile" 2>&1 ; then
+		# If the USB key fails, try mounting the ISO.
+		if ! mount_ISO "$mntdir" > "$tfile2" 2>&1; then
 			if [[ $VERBOSE -eq 1 ]]; then
 			    eecho "Can't find install media: USB stick errors:"
 			    eecho ""
-			    cat $tfile 1>&2
+			    cat "$tfile" 1>&2
 			    eecho ""
 			    eecho "ISO errors"
 			    eecho ""
-			    cat $tfile2 1>&2
+			    cat "$tfile2" 1>&2
 			fi
-			rm -f $tfile $tfile2
+			rm -f "$tfile" "$tfile2"
 			return 1
 		fi
 	fi
 
-	rm -f $tfile $tfile2
+	rm -f "$tfile" "$tfile2"
 	return 0
 }
 
@@ -197,14 +195,14 @@ mount_installmedia() {
 # XXX WARNING - there is a security discussion to be had about the integrity
 # of the source.
 install() {
-	piname_present_get_bootfs $1 $2
+	piname_present_get_bootfs "$1" "$2"
 	tdir=$(mktemp -d)
-	mkdir ${tdir}/mnt
+	mkdir "${tdir}/mnt"
 
 	# $1 contains a "source".  Deal with it correctly in the big
 	# if/elif/else block.  Once done, we can copy over bits into $tdir or
 	# ${tdir}/mnt.
-	# 
+	#
 
 	# Special-case of "latest"
 	if [[ "$1" == "latest" ]]; then
@@ -212,73 +210,72 @@ install() {
 		# URL_PREFIX.  Grab the latest-version ISO. Before proceeding,
 		# make sure it's the current one.
 		iso=yes
-		${CURL} -o ${tdir}/smartos.iso ${URL_PREFIX}/smartos-latest.iso
-		if [[ $? -ne 0 ]]; then
-			code=$?
-			/bin/rm -rf ${tdir}
+		"${CURL[@]}" -o "${tdir}/smartos.iso" "${URL_PREFIX}/smartos-latest.iso"
+		code=$?
+		if [[ $code -ne 0 ]]; then
+			/bin/rm -rf "${tdir}"
 			fatal "Curl exit code $code"
 		fi
-		mount -F hsfs ${tdir}/smartos.iso ${tdir}/mnt
+		mount -F hsfs "${tdir}/smartos.iso" "${tdir}/mnt"
 
 		# For now, assume boot stamp and PI stamp are the same on an ISO...
-		stamp=$(cat ${tdir}/mnt/etc/version/boot)
+		stamp=$(cat "${tdir}/mnt/etc/version/boot")
 	elif [[ "$1" == "media" ]]; then
 		# Scan the available media to find what we seek.  Same advice
 		# about making sure it's the current one.
 		iso=yes
-		mount_installmedia ${tdir}/mnt
-		if [[ $? -ne 0 ]]; then
-			/bin/rm -rf ${tdir}
+		if ! mount_installmedia "${tdir}/mnt" ; then
+			/bin/rm -rf "${tdir}"
 			err "Cannot find install media"
 		fi
 
 		# For now, assume boot stamp and PI stamp are the same on
 		# install media.
-		stamp=$(cat ${tdir}/mnt/etc/version/boot)
+		stamp=$(cat "${tdir}/mnt/etc/version/boot")
 	elif [[ -f $1 ]]; then
 		# File input!  Check for what kind, etc. etc.
 
 		# WARNING:  Depends GREATLY on the output of file(1)
-		filetype=$(file $1 | awk '{print $2}')
+		filetype=$(file "$1" | awk '{print $2}')
 		if [[ "$filetype" == "ISO" ]]; then
 			# Assume .iso file.
 			iso=yes
-			mount -F hsfs $1 ${tdir}/mnt
-			stamp=$(cat ${tdir}/mnt/etc/version/boot)
+			mount -F hsfs "$1" "${tdir}/mnt"
+			stamp=$(cat "${tdir}/mnt/etc/version/boot")
 		elif [[ "$filetype" == "gzip" ]]; then
 			# SmartOS PI.  Let's confirm it's actually a .tgz...
-			gtar -xzOf $1 > /dev/null 2>&1
-			if [[ $? -ne 0 ]]; then
-				/bin/rm -rf ${tdir}
+
+			if ! gtar -xzOf "$1" > /dev/null 2>&1; then
+				/bin/rm -rf "${tdir:?}"
 				err "File $1 is not an ISO or a .tgz file."
 			fi
 			# We're most-likely good here.  NOTE: SmartOS/Triton
 			# PI files expand to platform-$STAMP.  Fix it here
 			# before proceeding.
-			gtar -xzf $1 -C ${tdir}/mnt
-			mv ${tdir}/mnt/platform-* ${tdir}/mnt/platform
+			gtar -xzf "$1" -C "${tdir}/mnt"
+			mv "${tdir}/mnt/platform-*" "${tdir}/mnt/platform"
 			iso=no
-			stamp=$(cat ${tdir}/mnt/platform/etc/version/platform)
+			stamp=$(cat "${tdir}/mnt/platform/etc/version/platform")
 		else
-			/bin/rm -rf ${tdir}
+			/bin/rm -rf "${tdir:?}"
 			err "Unknown file type for $1"
 		fi
 	else
 		# Explicit boot stamp or URL.
 
 		# Do a URL reality check.
-		${CURL} -o ${tdir}/download $1
+		"${CURL[@]}" -o "${tdir}/download" "$1"
 		if [[ -e ${tdir}/download ]]; then
 			# Recurse with the downloaded file.
 			dload=$(mktemp)
-			mv -f ${tdir}/download $dload
-			/bin/rm -rf ${tdir}
+			mv -f "${tdir}/download" "$dload"
+			/bin/rm -rf "${tdir}"
 
 			# in case `install` exits out early...
-			( pwait $$ ; rm -f $dload ) &
+			( pwait $$ ; rm -f "$dload" ) &
 			vecho "Installing $1"
 			vecho "	   (downloaded to $dload)"
-			install $dload $2
+			install "$dload" "$2"
 			return 0
 		fi
 		# Else we treat it like a boot stamp.
@@ -286,7 +283,7 @@ install() {
 		# Now that we think it's a boot stamp, check if it's the
 		# current one or if it exists.
 		if [[ -d ${bootfs}/platform-${1} ]]; then
-			/bin/rm -rf ${tdir}
+			/bin/rm -rf "${tdir}"
 			eecho "PI-stamp $1 appears to be already on /${bootfs}"
 			err "Use  piadm remove $1  to remove any old copies."
 		fi
@@ -294,32 +291,30 @@ install() {
 		# Confirm this is a legitimate build stamp.
 		# Use conventions from site hosted in URL_PREFIX.
 		checkurl=${URL_PREFIX}/$1/index.html
-		${CURL} $checkurl | head | grep -qv "not found"
-		if [[ $? -ne 0 ]]; then
+		if ! "${CURL[@]}" "$checkurl" | head | grep -qv "not found" ; then
 			eecho "PI-stamp $1" \
 				"is invalid for download from $URL_PREFIX"
 			usage
 		fi
-		${CURL} -o ${tdir}/smartos.iso \
-			${URL_PREFIX}/$1/smartos-${1}.iso
-		if [[ $? -ne 0 ]]; then
-			code=$?
-			/bin/rm -rf ${tdir}
+		"${CURL[@]}" -o "${tdir}/smartos.iso" "${URL_PREFIX}/$1/smartos-${1}.iso"
+		code=$?
+		if [[ $code -ne 0 ]]; then
+			/bin/rm -rf "${tdir}"
 			fatal "PI-stamp $1 -- curl exit code $code"
 		fi
-		mount -F hsfs ${tdir}/smartos.iso ${tdir}/mnt
-		if [[ $? -ne 0 ]]; then
-			code=$?
-			/bin/rm -rf ${tdir}
+		mount -F hsfs "${tdir}/smartos.iso" "${tdir}/mnt"
+		code=$?
+		if [[ $code -ne 0 ]]; then
+			/bin/rm -rf "${tdir}"
 			fatal "PI-stamp $1 -- mount exit code $code"
 		fi
 		iso=yes
 		stamp=$1
 		# Reality-check boot stamp.
-		bstamp=$(cat ${tdir}/mnt/etc/version/boot)
-		if [[ "$stamp" != "$bstamp" ]]; then
-			umount ${tdir}/mnt
-			/bin/rm -rf ${tdir}
+		bstamp=$(cat "${tdir}/mnt/etc/version/boot")
+		if [[ $stamp != "$bstamp" ]]; then
+			umount "${tdir}/mnt"
+			/bin/rm -rf "${tdir}"
 			err "Boot bits stamp says $bstamp," \
 			    "vs. argument stamp $stamp"
 		fi
@@ -334,47 +329,47 @@ install() {
 
 	if [[ "$iso" == "yes" ]]; then
 		# Match-check boot stamp and platform stamp.
-		pstamp=$(cat ${tdir}/mnt/platform/etc/version/platform)
+		pstamp=$(cat "${tdir}/mnt/platform/etc/version/platform")
 		if [[ "$stamp" != "$pstamp" ]];	then
-			umount ${tdir}/mnt
-			/bin/rm -rf ${tdir}
+			umount "${tdir}/mnt"
+			/bin/rm -rf "${tdir}"
 			err "Boot stamp $stamp mismatches platform stamp" \
 				"$pstamp"
 		fi
 
-		if [[ -e /${bootfs}/boot-${stamp} ]]; then
-			umount ${tdir}/mnt
-			/bin/rm -rf ${tdir}
+		if [[ -e "/${bootfs}/boot-${stamp}" ]]; then
+			umount "${tdir}/mnt"
+			/bin/rm -rf "${tdir}"
 			eecho "PI-stamp $stamp has boot bits already" \
 				"on /${bootfs}"
 			err "Use  piadm remove $stamp " \
 				"to remove any old copies."
 		fi
-		mkdir /${bootfs}/boot-${stamp} || \
+		mkdir "/${bootfs}/boot-${stamp}" || \
 			eecho "Can't mkdir /${bootfs}/boot-${stamp}"
-		tar -cf - -C ${tdir}/mnt/boot . | \
-			tar -xf - -C /${bootfs}/boot-${stamp} || \
+		tar -cf - -C "${tdir}/mnt/boot" . | \
+			tar -xf - -C "/${bootfs}/boot-${stamp}" || \
 			eecho "Problem in tar of boot bits"
 	fi
 
 	if [[ -e /${bootfs}/platform-${stamp} ]]; then
-		if [[ "$iso" == "yes" ]]; then
-			umount ${tdir}/mnt
+		if [[ $iso == "yes" ]]; then
+			umount "${tdir}/mnt"
 		fi
-		/bin/rm -rf ${tdir}
+		/bin/rm -rf "${tdir}"
 		eecho "PI-stamp $stamp appears to be already on /${bootfs}"
 		err "Use   piadm remove $stamp	 to remove any old copies."
 	fi
-	mkdir /${bootfs}/platform-${stamp} || \
+	mkdir "/${bootfs}/platform-${stamp}" || \
 		eecho "Can't mkdir /${bootfs}/platform-${stamp}"
-	tar -cf - -C ${tdir}/mnt/platform . | \
-		tar -xf - -C /${bootfs}/platform-${stamp} || \
+	tar -cf - -C "${tdir}/mnt/platform" . | \
+		tar -xf - -C "/${bootfs}/platform-${stamp}" || \
 		eecho "Problem in tar of platform bits"
 
 	if [[ "$iso" == "yes" ]]; then
-		umount ${tdir}/mnt
+		umount "${tdir}/mnt"
 	fi
-	/bin/rm -rf ${tdir}
+	/bin/rm -rf "${tdir:?}"
 
 	if [[ ! -d /${bootfs}/platform-${stamp} ]]; then
 		fatal "Installation problem (no ${bootfs}/platform-${stamp})"
@@ -398,11 +393,11 @@ list() {
 		pool=$1
 	fi
 
-	poolpresent $pool
+	poolpresent "$pool"
 
 	getbootable
-	for bootfs in ${allbootfs[@]}; do
-		bfspool=$(echo $bootfs | awk -F/ '{print $1}')
+	for bootfs in "${allbootfs[@]}"; do
+		bfspool=$(echo "$bootfs" | awk -F/ '{print $1}')
 		if [[ "$pool" != "" && "$bfspool" != "$pool" ]]; then
 			# If we specify a pool for listing, skip ones not in
 			# the pool.
@@ -412,31 +407,31 @@ list() {
 			corrupt "WARNING: Bootable filesystem $bootfs" \
 				"has non-symlink platform"
 		fi
-		cd /$bootfs
+		cd "/$bootfs" || fatal "Could not chdir to /$bootfs"
 		bootbitsstamp=$(cat etc/version/boot)
 		bootstamp=$(cat platform/etc/version/platform)
 		mapfile -t pis \
-			< <(cd /$bootfs ; cat platform-*/etc/version/platform)
-		for pi in ${pis[@]}; do
-			if [[ $activestamp == $pi ]]; then
+			< <(cd "/$bootfs" || exit; cat platform-*/etc/version/platform)
+		for pi in "${pis[@]}"; do
+			if [[ $activestamp == "$pi" ]]; then
 				active="yes"
 			else
 			    active="no"
 			fi
-			if [[ $bootstamp == $pi ]]; then
+			if [[ $bootstamp == "$pi" ]]; then
 				booting="yes"
 			else
 				booting="no"
 			fi
-			if [[ $bootbitsstamp == $pi ]]; then
+			if [[ $bootbitsstamp == "$pi" ]]; then
 				bootbits="next"
-			elif [[ -d boot-$pi ]]; then
+			elif [[ -d "boot-$pi" ]]; then
 				bootbits="available"
 			else
 				bootbits="none"
 			fi
 			printf "%-18s %-30s %-12s %-5s %-5s\n" \
-				$pi $bootfs $bootbits $active $booting
+				"$pi" "$bootfs" "$bootbits" "$active" "$booting"
 		done
 	done
 }
@@ -456,7 +451,7 @@ update_boot_sectors() {
 	# Reality check the pool was created with -B.
 	# First way to do this is to check for the `bootsize` property not
 	# its default, which is NO bootsize.
-	if [[ $(zpool list -Ho bootsize $pool) == "-" ]]; then
+	if [[ $(zpool list -Ho bootsize "$pool") == "-" ]]; then
 		# No bootsize is a first-cut test.  It passes if the pool was
 		# created with `zpool create -B`. There's one other that needs
 		# to be performed, because some bootable pools are manually
@@ -465,13 +460,13 @@ update_boot_sectors() {
 
 		# Use fstyp to confirm if this is a manually created EFI
 		# System Partition (ESP)
-		type=$(fstyp /dev/dsk/${boot_devices[0]}s0)
+		type=$(fstyp "/dev/dsk/${boot_devices[0]}s0")
 		if [[ "$type" == "pcfs" ]]; then
 			# If we detect PCFS on s0, it's LIKELY an EFI System
 			# Partition that was crafted manually.  Use s1 if it's
 			# ZFS, or bail if it's not.
 
-			s1type=$(fstyp /dev/dsk/${boot_devices[0]}s1)
+			s1type=$(fstyp "/dev/dsk/${boot_devices[0]}s1")
 			if [[ "$s1type" != "zfs" ]]; then
 				fatal "Unusual configuration," \
 					"${boot_devices[0]}s1 not ZFS"
@@ -494,15 +489,16 @@ update_boot_sectors() {
 			fi
 			# otherwise mount the ESP and trash it.
 			tdir=$(mktemp -d)
-			mount -F pcfs /dev/dsk/${a}s0 ${tdir}
-			if [[ $? -ne 0 ]]; then
+			if mount -F pcfs "/dev/dsk/${a}s0" "${tdir:?}" ; then
+				some=1
+			else
 				eecho "disk $a has no PCFS ESP, it seems"
 				continue
 			fi
 			# Just take out the EFI directory, in case someone
 			# is using it for something ELSE also.
-			/bin/rm -rf ${tdir}/EFI
-			umount ${tdir} && rmdir "$tdir"
+			/bin/rm -rf "${tdir}/EFI"
+			umount "$tdir" && rmdir "$tdir"
 			# If we make it here, at least some disks had
 			# ESP and we managed to clean them out.  "some" below
 			# will get set.
@@ -512,16 +508,14 @@ update_boot_sectors() {
 			# loader-into-EFI-System-Partition this way.
 			# Trailing / is important in the -b argument
 			# because boot is actually a symlink.
-			installboot -m -b /${bootfs}/boot/ \
-				/${bootfs}/boot/pmbr \
-				/${bootfs}/boot/gptzfsboot \
-				/dev/rdsk/${a}${suffix} > /dev/null 2>&1 || \
-				eecho \
-				"WARNING: Can't installboot on ${a}${suffix}"
-		fi
-
-		if [[ $? -eq 0 ]]; then
-			some=1
+			if installboot -m -b "/${bootfs}/boot/" \
+				"/${bootfs}/boot/pmbr" \
+				"/${bootfs}/boot/gptzfsboot" \
+				"/dev/rdsk/${a}${suffix}" > /dev/null 2>&1 ; then
+				some=1
+			else
+				eecho "WARNING: Can't installboot on ${a}${suffix}"
+			fi
 		fi
 	done
 
@@ -534,17 +528,17 @@ update_boot_sectors() {
 
 activate() {
 	pistamp=$1
-	piname_present_get_bootfs $pistamp $2
-	pool=$(echo $bootfs | awk -F/ '{print $1}')
+	piname_present_get_bootfs "$pistamp" "$2"
+	pool=$(echo "$bootfs" | awk -F/ '{print $1}')
 
-	cd /$bootfs
-	if [[ -d platform-$pistamp ]]; then
+	cd "/$bootfs" || fatal "Could not chdir to /$bootfs"
+	if [[ -d "platform-$pistamp" ]]; then
 		if [[ -f platform/etc/version/platform ]]; then
 			bootstamp=$(cat platform/etc/version/platform)
 		else
 			bootstamp=""
 		fi
-		if [[ $bootstamp == $pistamp ]]; then
+		if [[ $bootstamp == "$pistamp" ]]; then
 			vecho "NOTE: $pistamp is the current active PI."
 			return
 		fi
@@ -559,15 +553,15 @@ activate() {
 	# we can do the same with the boot.
 	if [[ -d boot-$pistamp ]]; then
 		rm -f boot
-		ln -s ./boot-$pistamp boot
+		ln -s ./boot-"$pistamp" boot
 		mkdir -p etc/version
-		echo $pistamp > etc/version/boot
-		update_boot_sectors $pool $bootfs
-		grep -q 'fstype="ufs"' ./boot/loader.conf
-		if [[ $? -ne 0 ]]; then
-			# Fix the loader.conf for keep-the-ramdisk booting.
+		echo "$pistamp" > etc/version/boot
+		update_boot_sectors "$pool" "$bootfs"
+
+		# Fix the loader.conf for keep-the-ramdisk booting.
+		grep -q 'fstype="ufs"' ./boot/loader.conf || \
 			echo 'fstype="ufs"' >> ./boot/loader.conf
-		fi
+
 		vecho "    with a new boot image,"
 	else
 		vecho "	   WARNING: $pistamp has no matching boot image, using"
@@ -578,20 +572,20 @@ activate() {
 		fi
 	fi
 
-	vecho "    boot image " $(cat etc/version/boot)
+	vecho "    boot image " "$(cat etc/version/boot)"
 
 	rm -f platform
-	ln -s ./platform-$pistamp platform
+	ln -s "./platform-$pistamp" platform
 }
 
 remove() {
 	pistamp=$1
-	piname_present_get_bootfs $pistamp $2
-	cd /$bootfs
+	piname_present_get_bootfs "$pistamp" "$2"
+	cd "/$bootfs" || fatal "Could not chdir to /$bootfs"
 	bootstamp=$(cat platform/etc/version/platform)
 
 	if [[ -d platform-$pistamp ]]; then
-		if [[ $bootstamp == $pistamp ]]; then
+		if [[ $bootstamp == "$pistamp" ]]; then
 			eecho "$pistamp is the next-booting PI." \
 		    		"Please activate another PI"
 			eecho "using 'piadm activate <other-PI-stamp>' first."
@@ -599,12 +593,11 @@ remove() {
 		fi
 
 		# Boot image processing.
-		if [[ -d boot-$pistamp ]]; then
+		if [[ -d "boot-$pistamp" ]]; then
 			# Boot bits may be older than the current PI, and the
 			# current PI may not have matching boot bits for some
 			# reason. Guard against shooting yourself in the foot.
-			grep -q $pistamp etc/version/boot
-			if [[ $? -eq 0 ]]; then
+			if ! grep -q "$pistamp" etc/version/boot; then
 				eecho "$pistamp is the current set of boot" \
 					"binaries.  Please"
 				eecho "activate another pi using" \
@@ -612,10 +605,10 @@ remove() {
 					"first."
 				usage
 			fi
-			/bin/rm -rf boot-$pistamp
+			/bin/rm -rf "boot-$pistamp"
 		fi
 
-		/bin/rm -rf platform-$pistamp
+		/bin/rm -rf "platform-$pistamp"
 	else
 		eecho "$pistamp is not a stamp for a PI on pool $pool"
 		usage
@@ -624,20 +617,17 @@ remove() {
 
 ispoolenabled() {
 	pool=$1
-	poolpresent $pool
+	poolpresent "$pool"
 
 	# SmartOS convention is $POOL/boot.
-	currbootfs=$(zpool list -Ho bootfs $pool)
-	if [[ "$currbootfs" == "${pool}/boot" ]]; then
-		output=$(zfs list -H $currbootfs 2>&1)
-		if [[ $? -eq 0 ]]; then
-			# We're bootable (at least bootable enough)
-			return 0
-		fi
+	currbootfs=$(zpool list -Ho bootfs "$pool")
+	if [[ $currbootfs == "${pool}/boot" ]]; then
+		# We're bootable (at least bootable enough)
+		zfs list -H "$currbootfs" 2>&1  && return 0
 		# else drop out to not-bootable, but this shouldn't happen.
 		vecho ".... odd, ${pool}/boot is pool's bootfs," \
 			"but isn't a filesystem"
-	elif [[ "$currbootfs" != "-" ]]; then
+	elif [[ $currbootfs != "-" ]]; then
 		eecho "It appears pool $pool has a different boot filesystem" \
 			"than the"
 		eecho "standard SmartOS filesystem of ${pool}/boot. It will" \
@@ -669,8 +659,7 @@ enablepool() {
 
 	bootfs=${pool}/boot
 
-	ispoolenabled $pool
-	if [[ $? -eq 0 ]]; then
+	if ispoolenabled "$pool" ; then
 		if [[ -d /${bootfs}/platform/. && -d /${bootfs}/boot/. ]]; then
 			echo "Pool $pool appears to be bootable."
 			echo "Use 'piadm install' or 'piadm activate' to" \
@@ -681,14 +670,11 @@ enablepool() {
 		# For now, proceed clobber-style.
 	fi
 
-	output=$(zfs list -H $bootfs 2>&1)
-	if [[ $? -ne 0 ]]; then
+	if ! zfs list -H "$bootfs" 2>&1; then
 		# Create a new bootfs and set it.
 		# NOTE:	 Encryption should be turned off for this dataset.
-		zfs create -o encryption=off $bootfs
-		if [[ $? -ne 0 ]]; then
+		zfs create -o encryption=off "$bootfs" || \
 			fatal "Cannot create $bootfs dataset"
-		fi
 	fi
 	# We MAY need to do some reality checking if the `zfs list` shows
 	# $bootfs. For now, just wing it. and plow forward.
@@ -696,17 +682,15 @@ enablepool() {
 	# At this point we have an existing SmartOS-standard boot filesystem,
 	# but it's not specified as bootfs in the pool.  Test if bootfs can be
 	# set...
-	zpool set bootfs=${bootfs} ${pool}
-	if [[ $? -ne 0 ]]; then
+	zpool set "bootfs=${bootfs}" "${pool}" || \
 		fatal "Cannot set bootfs for $pool"
-	fi
 	# Reset our view of available bootable pools.
 	getbootable
 
-	install $installsource $pool
+	install $installsource "$pool"
 
 	# install set 'installstamp' on our behalf.
-	activate $installstamp $pool
+	activate "$installstamp" "$pool"
 }
 
 refresh_or_disable_pool() {
@@ -720,58 +704,54 @@ refresh_or_disable_pool() {
 
 	currbootfs=""
 	# ispoolenabled sets currbootfs as a side-effect.
-	ispoolenabled $pool
-	if [[ $? -ne 0 ]]; then
-		err "Pool $pool is not bootable, and cannot be disabled" \
-			"or refreshed"
-	fi
+	ispoolenabled "$pool" || \
+		err "Pool $pool is not bootable, and cannot be disabled or refreshed"
 
 	if [[ "$flag" == "-d" ]]; then
 		vecho "Disabling bootfs on pool $pool"
-		zpool set bootfs="" $pool
+		zpool set bootfs="" "$pool"
 	else
 		vecho "Refreshing boot sectors and/or ESP on pool $pool"
 	fi
 
-	update_boot_sectors $pool $currbootfs $flag
+	update_boot_sectors "$pool" "$currbootfs" "$flag"
 
 	return 0
 }
 
 bootable() {
-	if [[ "$1" == "-d" || "$1" == "-r" ]]; then
-		refresh_or_disable_pool $1 $2
+	if [[ $1 == "-d" || "$1" == "-r" ]]; then
+		refresh_or_disable_pool "$1" "$2"
 		return
-	elif [[ "$1" == "-e" ]]; then
+	elif [[ $1 == "-e" ]]; then
 		shift 1
-		enablepool $@
+		enablepool "$@"
 		return
 	fi
 
 	# If we reach here, we're querying about a pool.
 
 	if [[ "$1" == "" ]]; then
-		allpools=$(zpool list -Ho name)
+		mapfile -t allpools < <(zpool list -Ho name)
 	else
 		# Reality check for bad pool name.
-		poolpresent $1
+		poolpresent "$1"
 		# Or have a list of one pool...
-		allpools=$1
+		allpools=( "$1" )
 	fi
 
 	# We're guaranteed that, modulo background processes, $allpools has a
 	# list of actual pools, even if it's a list-of-one.
 
-	for pool in $allpools; do
-		zpool list -Ho bootfs $pool | grep -q ${pool}/boot
-		if [[ $? -eq 0 ]]; then
+	for pool in "${allpools[@]}"; do
+		if zpool list -Ho bootfs "$pool" | grep -q "${pool}/boot" ; then
 			bootable="BIOS"
 			# Check for pcfs partition on pool disks.
 			mapfile -t boot_devices < \
 				<(zpool list -vHP "${pool}" | \
 				grep -E 'c[0-9]+' | awk '{print $1}')
 			for a in "${boot_devices[@]}"; do
-				noslice=$(echo $a | sed -E 's/s[0-9]+//g')
+				noslice=$(echo "$a" | sed -E 's/s[0-9]+//g')
 				tdir=$(mktemp -d)
 				# Assume that s0 on the physical disk would be
 				# where the EFI System Partition (ESP) lives.
@@ -780,21 +760,21 @@ bootable() {
 				# it. Do this instead of just checking for
 				# bootsize because we can further
 				# integrity-check here if need be.
-				mount -F pcfs /dev/dsk/${noslice}s0 $tdir \
-					> /dev/null 2>&1
-				if [[ $? -eq 0 && \
-					-f $tdir/EFI/Boot/bootx64.efi ]]; then
+
+				if mount -F pcfs "/dev/dsk/${noslice}s0" "$tdir" \
+					> /dev/null 2>&1 && \
+					[[ -f "$tdir/EFI/Boot/bootx64.efi" ]]; then
 					efi="and UEFI"
 				else
 					efi=""
 				fi
-				umount -f $tdir > /dev/null 2>&1 && rmdir $tdir
+				umount -f "$tdir" > /dev/null 2>&1 && rmdir "$tdir"
 			done
 		else
 			bootable="non-bootable"
 			efi=""
 		fi
-			   
+
 		printf "%-30s ==> %s %s\n" "$pool" "$bootable" "$efi"
 	done
 }
@@ -815,7 +795,7 @@ shift 1
 
 case $cmd in
 	activate | assign )
-		activate $@
+		activate "$@"
 		;;
 
 	avail )
@@ -823,19 +803,19 @@ case $cmd in
 		;;
 
 	bootable )
-		bootable $@
+		bootable "$@"
 		;;
 
 	install )
-		install $@
+		install "$@"
 		;;
 
 	list )
-		list $@
+		list "$@"
 		;;
 
 	remove )
-		remove $@
+		remove "$@"
 		;;
 
 	*)

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -632,7 +632,7 @@ ispoolenabled() {
 	currbootfs=$(zpool list -Ho bootfs "$pool")
 	if [[ $currbootfs == "${pool}/boot" ]]; then
 		# We're bootable (at least bootable enough)
-		zfs list -H "$currbootfs" 2>&1  && return 0
+		zfs list -H "$currbootfs" > /dev/null 2>&1  && return 0
 		# else drop out to not-bootable, but this shouldn't happen.
 		vecho ".... odd, ${pool}/boot is pool's bootfs," \
 			"but isn't a filesystem"

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -80,8 +80,17 @@ activestamp=$(uname -v | sed 's/joyent_//g')
 declare installstamp
 
 poolpresent() {
-	# Works for an empty $1, which is "all of them" or "unspecified"
-	if ! zpool list "$1" > /dev/null 2>&1 ; then
+	local pool_len cmd
+	pool_len="${#1}"
+	# This seems a bit obtuse, but we need to pass the pool specification we
+	# received on the command line to zpool verbatim, but having an empty
+	# variable passed to zpool won't give us any valid output.
+	if (( pool_len == 0 )); then
+		zp_cmd=( zpool list )
+	else
+		zp_cmd=( zpool list "$1" )
+	fi
+	if ! "${zp_cmd[@]}" > /dev/null 2>&1 ; then
 		eecho "Pool $1 not present"
 		usage
 	fi
@@ -253,7 +262,7 @@ install() {
 			# PI files expand to platform-$STAMP.  Fix it here
 			# before proceeding.
 			gtar -xzf "$1" -C "${tdir}/mnt"
-			mv "${tdir}/mnt/platform-*" "${tdir}/mnt/platform"
+			mv "${tdir}"/mnt/platform-* "${tdir}/mnt/platform"
 			iso=no
 			stamp=$(cat "${tdir}/mnt/platform/etc/version/platform")
 		else

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -679,7 +679,7 @@ enablepool() {
 		# For now, proceed clobber-style.
 	fi
 
-	if ! zfs list -H "$bootfs" 2>&1; then
+	if ! zfs list -H "$bootfs" > /dev/null 2>&1; then
 		# Create a new bootfs and set it.
 		# NOTE:	 Encryption should be turned off for this dataset.
 		zfs create -o encryption=off "$bootfs" || \


### PR DESCRIPTION
There *should* be no difference in behavior, except for the elimination of various undefined or bug behaviors.

That being said, there's a lot changing here so we'll want to test it against all of our known use cases.