### PR TITLE
OS-8209 piadm should allow injecting loader.*.local

### DIFF
--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -69,6 +69,11 @@ piadm(1M) -- Manage SmartOS Platform Images
     itself without issue.  Occasionally, however, a PI will have Boot Image
     changes also that need to accompany it.
 
+    Boot images can be customized by providing loader.conf.local and/or
+    loader.rc.local files in POOL/boot/common/. When a new boot image is
+    installed using `piadm install` these files are symlinked into the
+    images.
+
 ## BOOTABLE POOLS
 
     A SmartOS bootable pool (POOL in the examples) contains:
@@ -293,3 +298,8 @@ The following exit values are returned:
     if it's `zones`, a machine can still be booted with a USB stick, CD-ROM,
     or other method of booting SmartOS.  A bootable pool can then be
     repaired using piadm(1M) from the USB stick or CD-ROM.
+
+    Boot image customization is done at install time, other boot images
+    already present will not be updated. Older versions of piadm can still
+    be used to switch to and from boot images that have been customized but
+    won't be able to customize images.

--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -72,7 +72,7 @@ piadm(1M) -- Manage SmartOS Platform Images
 
     The behavior of loader can be controlled by providing loader.conf.local
     and/or loader.rc.local files in the ${BOOTPOOL}/boot-${VERSION}
-    directory. Loader config files can also be placed in ${BOOTPOOL}/common,
+    directory. Loader config files can also be placed in ${BOOTPOOL}/custom,
     and will be used by all subsequently installed boot images.
 
     See loader.conf(4) and loader(5) for the format of these files.

--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -250,6 +250,49 @@ piadm(1M) -- Manage SmartOS Platform Images
  [root@smartos ~]#
 ```
 
+### Customizing a boot image to load /etc/ppt_aliasses and /etc/ppt_matches
+
+```
+ [root@smartos ~]# piadm list
+ PI STAMP           BOOTABLE FILESYSTEM            BOOT IMAGE   NOW   NEXT
+ 20200714T195617Z   standalone/boot                next         yes   yes
+ [root@smartos ~]# mkdir -p /standalone/boot/common
+ [root@smartos ~]# cat > /standalone/boot/common/loader.conf.local <<EOF
+ > ppt_aliases_type="file"
+ > ppt_aliases_name="/common/etc/ppt_aliases"
+ > ppt_aliases_flags="name=/etc/ppt_aliases"
+ > ppt_matches_load="YES"
+ > ppt_matches_type="file"
+ > ppt_matches_name="/common/etc/ppt_matches"
+ > ppt_matches_flags="name=/etc/ppt_matches"
+ > EOF
+ [root@smartos ~]# mkdir -p /standalone/boot/common/etc
+ [root@smartos ~]# cat > /standalone/boot/common/etc/ppt_aliases <<EOF
+ > ppt "/pci@5e,0/pci8086,2030@0/pci8086,37c0@0/pci8086,37c5@3/pci15d9,37d2@0"
+ > EOF
+ [root@smartos ~]# cat > /standalone/boot/common/etc/ppt_matches <<EOF
+ > pciex8086,37d2
+ > EOF
+ [root@smartos ~]# piadm install 20200910T013122Z
+ [root@smartos ~]# ls -l /standalone/boot/boot-20200910T013122Z
+ total 527245
+ -r--r--r--   1 root     root        1249 Sep 10 04:29 cdboot
+ drwxr-xr-x   2 root     root           3 Sep 10 04:29 defaults
+ -rw-------   1 root     root     268435456 Sep 10 04:29 efiboot.img
+ drwxr-xr-x   2 root     root          22 Sep 10 04:29 forth
+ -r--r--r--   1 root     root      142848 Sep 10 04:29 gptzfsboot
+ -r--r--r--   1 root     root       12303 Sep 10 04:29 joyent.png
+ -r--r--r--   1 root     root      405504 Sep 10 04:29 loader
+ -rw-r--r--   1 root     root         291 Sep 10 04:29 loader.conf
+ lrwxrwxrwx   1 root     root          27 Sep 23 13:26 loader.conf.local -> ../common/loader.conf.local
+ -r--r--r--   1 root     root       13586 Sep 10 04:29 loader.help
+ -r--r--r--   1 root     root         789 Sep 10 04:29 loader.rc
+ -r-xr-xr-x   1 root     root      565248 Sep 10 04:29 loader64.efi
+ -r--r--r--   1 root     root         512 Sep 10 04:29 pmbr
+ -r--r--r--   1 root     root        2561 Sep 10 04:29 triton.png
+ [root@smartos ~]#
+```
+
 ## EXIT STATUS
 
 The following exit values are returned:
@@ -302,4 +345,6 @@ The following exit values are returned:
     Boot image customization is done at install time, other boot images
     already present will not be updated. Older versions of piadm can still
     be used to switch to and from boot images that have been customized but
-    won't be able to customize images.
+    won't be able to customize images. Because symlinks are used, changes
+    to common/loader.conf.local and common/loader.rc.local will be
+    be applied to all boot images that have been customized.

--- a/man/usr/share/man/man1m/piadm.1m.md
+++ b/man/usr/share/man/man1m/piadm.1m.md
@@ -69,10 +69,13 @@ piadm(1M) -- Manage SmartOS Platform Images
     itself without issue.  Occasionally, however, a PI will have Boot Image
     changes also that need to accompany it.
 
-    Boot images can be customized by providing loader.conf.local and/or
-    loader.rc.local files in POOL/boot/common/. When a new boot image is
-    installed using `piadm install` these files are symlinked into the
-    images.
+
+    The behavior of loader can be controlled by providing loader.conf.local
+    and/or loader.rc.local files in the ${BOOTPOOL}/boot-${VERSION}
+    directory. Loader config files can also be placed in ${BOOTPOOL}/common,
+    and will be used by all subsequently installed boot images.
+
+    See loader.conf(4) and loader(5) for the format of these files.
 
 ## BOOTABLE POOLS
 
@@ -250,49 +253,6 @@ piadm(1M) -- Manage SmartOS Platform Images
  [root@smartos ~]#
 ```
 
-### Customizing a boot image to load /etc/ppt_aliasses and /etc/ppt_matches
-
-```
- [root@smartos ~]# piadm list
- PI STAMP           BOOTABLE FILESYSTEM            BOOT IMAGE   NOW   NEXT
- 20200714T195617Z   standalone/boot                next         yes   yes
- [root@smartos ~]# mkdir -p /standalone/boot/common
- [root@smartos ~]# cat > /standalone/boot/common/loader.conf.local <<EOF
- > ppt_aliases_type="file"
- > ppt_aliases_name="/common/etc/ppt_aliases"
- > ppt_aliases_flags="name=/etc/ppt_aliases"
- > ppt_matches_load="YES"
- > ppt_matches_type="file"
- > ppt_matches_name="/common/etc/ppt_matches"
- > ppt_matches_flags="name=/etc/ppt_matches"
- > EOF
- [root@smartos ~]# mkdir -p /standalone/boot/common/etc
- [root@smartos ~]# cat > /standalone/boot/common/etc/ppt_aliases <<EOF
- > ppt "/pci@5e,0/pci8086,2030@0/pci8086,37c0@0/pci8086,37c5@3/pci15d9,37d2@0"
- > EOF
- [root@smartos ~]# cat > /standalone/boot/common/etc/ppt_matches <<EOF
- > pciex8086,37d2
- > EOF
- [root@smartos ~]# piadm install 20200910T013122Z
- [root@smartos ~]# ls -l /standalone/boot/boot-20200910T013122Z
- total 527245
- -r--r--r--   1 root     root        1249 Sep 10 04:29 cdboot
- drwxr-xr-x   2 root     root           3 Sep 10 04:29 defaults
- -rw-------   1 root     root     268435456 Sep 10 04:29 efiboot.img
- drwxr-xr-x   2 root     root          22 Sep 10 04:29 forth
- -r--r--r--   1 root     root      142848 Sep 10 04:29 gptzfsboot
- -r--r--r--   1 root     root       12303 Sep 10 04:29 joyent.png
- -r--r--r--   1 root     root      405504 Sep 10 04:29 loader
- -rw-r--r--   1 root     root         291 Sep 10 04:29 loader.conf
- lrwxrwxrwx   1 root     root          27 Sep 23 13:26 loader.conf.local -> ../common/loader.conf.local
- -r--r--r--   1 root     root       13586 Sep 10 04:29 loader.help
- -r--r--r--   1 root     root         789 Sep 10 04:29 loader.rc
- -r-xr-xr-x   1 root     root      565248 Sep 10 04:29 loader64.efi
- -r--r--r--   1 root     root         512 Sep 10 04:29 pmbr
- -r--r--r--   1 root     root        2561 Sep 10 04:29 triton.png
- [root@smartos ~]#
-```
-
 ## EXIT STATUS
 
 The following exit values are returned:
@@ -341,10 +301,3 @@ The following exit values are returned:
     if it's `zones`, a machine can still be booted with a USB stick, CD-ROM,
     or other method of booting SmartOS.  A bootable pool can then be
     repaired using piadm(1M) from the USB stick or CD-ROM.
-
-    Boot image customization is done at install time, other boot images
-    already present will not be updated. Older versions of piadm can still
-    be used to switch to and from boot images that have been customized but
-    won't be able to customize images. Because symlinks are used, changes
-    to common/loader.conf.local and common/loader.rc.local will be
-    be applied to all boot images that have been customized.

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -360,11 +360,11 @@ install() {
 			tar -xf - -C "/${bootfs}/boot-${stamp}" || \
 			eecho "Problem in tar of boot bits"
 
-		[[ -e "/${bootfs}/common/loader.conf.local" ]] && \
-			ln -sf "../common/loader.conf.local" \
+		[[ -e "/${bootfs}/custom/loader.conf.local" ]] && \
+			ln -sf "../custom/loader.conf.local" \
 				"/${bootfs}/boot-${stamp}/loader.conf.local"
-		[[ -e "/${bootfs}/common/loader.rc.local" ]] && \
-			ln -sf "../common/loader.rc.local" \
+		[[ -e "/${bootfs}/custom/loader.rc.local" ]] && \
+			ln -sf "../custom/loader.rc.local" \
 				"/${bootfs}/boot-${stamp}/loader.rc.local"
 	fi
 

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -359,6 +359,13 @@ install() {
 		tar -cf - -C "${tdir}/mnt/boot" . | \
 			tar -xf - -C "/${bootfs}/boot-${stamp}" || \
 			eecho "Problem in tar of boot bits"
+
+		[[ -e "/${bootfs}/common/loader.conf.local" ]] && \
+			ln -sf "../common/loader.conf.local" \
+				"/${bootfs}/boot-${stamp}/loader.conf.local"
+		[[ -e "/${bootfs}/common/loader.rc.local" ]] && \
+			ln -sf "../common/loader.rc.local" \
+				"/${bootfs}/boot-${stamp}/loader.rc.local"
 	fi
 
 	if [[ -e /${bootfs}/platform-${stamp} ]]; then


### PR DESCRIPTION
After this change piadm will try to symlink `loader.conf.local` and `loader.rc.local` on the install action.

The symlinking is only done when:
- installing boot bits
- either loader.conf.local or loader.rc.local exist in /BOOTFS/common/

This should make it easier for people to load for example a custom ppt_matches and ppt_aliases file.

Testing I've done:
- build a new pi with this applied
- install pi and boot it
- create /standalone/boot/common
- copy my ppt_aliases, ppt_matches, sd.conf, ... to the common directory (mirroring the final location)
- copy my existing loader.conf.local (and modified the paths) to common directory
- create test loader.rc.local that swaps bg and foreground colors
- build a new pi
- install new pi using `piadm install XXX.iso`
- verified that a relative symlink was present in boot-STAMP
- reboot and double check serial output for my files to be loaded (OMG the VGA output is white and I regret the choice)
- remove dummy loader.rc.local (leaving broken symlink)
- reboot
- loader.conf.local still loaded but back to normal colors on VGA (hurray)

Down side is that if you remove either loader.conf.local or loader.rc.local from your common directory it leaves a broken symlink.  It's probably safe to assume if the sysadmin is messing with this, they are smart enough to clean up the symlinks.
Even if they don't, there are no errors when booting.
