### PR TITLE
OS-8334 Bring OpenSSL 3 to the platform

### DIFF
--- a/tools/build_live
+++ b/tools/build_live
@@ -788,7 +788,7 @@ bi_setup_work_dir
 # Create and mount the "/" (root) ramdisk image:
 #
 bi_file_root="$bi_tmpdir/root.image"
-bi_root_size=300000
+bi_root_size=325000
 if strings "$bi_wsroot/proto/kernel/amd64/genunix" |
     grep "DEBUG enabled" >/dev/null; then
 	#

--- a/tools/build_live
+++ b/tools/build_live
@@ -11,7 +11,7 @@
 #
 
 #
-# Copyright 2020 Joyent, Inc.
+# Copyright 2021 Joyent, Inc.
 #
 
 #


### PR DESCRIPTION
Only change needed for OpenSSL 3 is to increase the size of the ramdisk (again).