### PR TITLE
OS-8349 Move SmartOS build to base-64-lts 2021.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,7 +111,7 @@ pipeline {
         stage('check') {
             agent {
                 node {
-                    label 'platform:true && image_ver:18.4.0 && pkgsrc_arch:x86_64 && ' +
+                    label 'platform:true && image_ver:21.4.0 && pkgsrc_arch:x86_64 && ' +
                     'dram:16gb && !virt:kvm && fs:pcfs && fs:ufs && jenkins_agent:2'
                     customWorkspace "workspace/smartos-${BRANCH_NAME}-check"
                 }
@@ -154,7 +154,7 @@ set -o pipefail
                 // completes).
                 // Use ${BRANCH_NAME} instead.
                 node {
-                    label 'platform:true && image_ver:18.4.0 && pkgsrc_arch:x86_64 && ' +
+                    label 'platform:true && image_ver:21.4.0 && pkgsrc_arch:x86_64 && ' +
                     'dram:16gb && !virt:kvm && fs:pcfs && fs:ufs && jenkins_agent:2'
                     customWorkspace "workspace/smartos-${BRANCH_NAME}-default"
                 }
@@ -201,7 +201,7 @@ export ENGBLD_BITS_UPLOAD_IMGAPI=true
         stage('debug') {
             agent {
                 node {
-                    label 'platform:true && image_ver:18.4.0 && pkgsrc_arch:x86_64 && ' +
+                    label 'platform:true && image_ver:21.4.0 && pkgsrc_arch:x86_64 && ' +
                         'dram:16gb && !virt:kvm && fs:pcfs && fs:ufs && jenkins_agent:2'
                     customWorkspace "workspace/smartos-${BRANCH_NAME}-debug"
                 }
@@ -250,7 +250,7 @@ export PLAT_CONFIGURE_ARGS="-d $PLAT_CONFIGURE_ARGS"
         stage('gcc10') {
             agent {
                 node {
-                    label 'platform:true && image_ver:18.4.0 && pkgsrc_arch:x86_64 && ' +
+                    label 'platform:true && image_ver:21.4.0 && pkgsrc_arch:x86_64 && ' +
                         'dram:16gb && !virt:kvm && fs:pcfs && fs:ufs && jenkins_agent:2'
                     customWorkspace "workspace/smartos-${BRANCH_NAME}-gcc10"
                 }
@@ -293,7 +293,7 @@ export PLATFORM_DEBUG_SUFFIX=-gcc10
         stage('strap-cache') {
             agent {
                 node {
-                    label 'platform:true && image_ver:18.4.0 && pkgsrc_arch:x86_64 && ' +
+                    label 'platform:true && image_ver:21.4.0 && pkgsrc_arch:x86_64 && ' +
                         'dram:16gb && !virt:kvm && fs:pcfs && fs:ufs && jenkins_agent:2'
                     customWorkspace "workspace/smartos-${BRANCH_NAME}-strap-cache"
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline {
                 '<dt>-S</dt>\n' +
                 '<dd>do *not* run smatch [default is to run smatch]</dd>\n' +
                 '<dt>-s gcc10</dt>\n' +
-                '<dd>shadow compilers, comma delimited (gcc4,gcc#) [default: none]</dd>\n' +
+                '<dd>shadow compilers, comma delimited (gcc10,gcc#) [default: none]</dd>\n' +
                 '</dl>'
         )
         text(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,7 +112,7 @@ pipeline {
             agent {
                 node {
                     label 'platform:true && image_ver:21.4.0 && pkgsrc_arch:x86_64 && ' +
-                    'dram:16gb && !virt:kvm && fs:pcfs && fs:ufs && jenkins_agent:2'
+                    'dram:16gb && !virt:kvm && fs:pcfs && fs:ufs && jenkins_agent:3'
                     customWorkspace "workspace/smartos-${BRANCH_NAME}-check"
                 }
             }
@@ -155,7 +155,7 @@ set -o pipefail
                 // Use ${BRANCH_NAME} instead.
                 node {
                     label 'platform:true && image_ver:21.4.0 && pkgsrc_arch:x86_64 && ' +
-                    'dram:16gb && !virt:kvm && fs:pcfs && fs:ufs && jenkins_agent:2'
+                    'dram:16gb && !virt:kvm && fs:pcfs && fs:ufs && jenkins_agent:3'
                     customWorkspace "workspace/smartos-${BRANCH_NAME}-default"
                 }
             }
@@ -202,7 +202,7 @@ export ENGBLD_BITS_UPLOAD_IMGAPI=true
             agent {
                 node {
                     label 'platform:true && image_ver:21.4.0 && pkgsrc_arch:x86_64 && ' +
-                        'dram:16gb && !virt:kvm && fs:pcfs && fs:ufs && jenkins_agent:2'
+                        'dram:16gb && !virt:kvm && fs:pcfs && fs:ufs && jenkins_agent:3'
                     customWorkspace "workspace/smartos-${BRANCH_NAME}-debug"
                 }
             }
@@ -251,7 +251,7 @@ export PLAT_CONFIGURE_ARGS="-d $PLAT_CONFIGURE_ARGS"
             agent {
                 node {
                     label 'platform:true && image_ver:21.4.0 && pkgsrc_arch:x86_64 && ' +
-                        'dram:16gb && !virt:kvm && fs:pcfs && fs:ufs && jenkins_agent:2'
+                        'dram:16gb && !virt:kvm && fs:pcfs && fs:ufs && jenkins_agent:3'
                     customWorkspace "workspace/smartos-${BRANCH_NAME}-gcc10"
                 }
             }
@@ -294,7 +294,7 @@ export PLATFORM_DEBUG_SUFFIX=-gcc10
             agent {
                 node {
                     label 'platform:true && image_ver:21.4.0 && pkgsrc_arch:x86_64 && ' +
-                        'dram:16gb && !virt:kvm && fs:pcfs && fs:ufs && jenkins_agent:2'
+                        'dram:16gb && !virt:kvm && fs:pcfs && fs:ufs && jenkins_agent:3'
                     customWorkspace "workspace/smartos-${BRANCH_NAME}-strap-cache"
                 }
             }

--- a/README.md
+++ b/README.md
@@ -170,19 +170,19 @@ inside of a non-global zone.
 
 ### Importing the Zone Image
 
-The SmartOS build currently uses the `base-64-lts 18.4.0` image
-which has a UUID of `c193a558-1d63-11e9-97cf-97bb3ee5c14f `. To import
+The SmartOS build currently uses the `base-64-lts 21.4.0` image
+which has a UUID of `c8715b60-7e98-11ec-82d1-03d16599f529 `. To import
 the image, you should run the imgadm command from the global zone:
 
 ```
-# imgadm import c193a558-1d63-11e9-97cf-97bb3ee5c14f
-Importing c193a558-1d63-11e9-97cf-97bb3ee5c14f (base-64-lts@18.4.0) from "https://images.joyent.com"
-Gather image c193a558-1d63-11e9-97cf-97bb3ee5c14f ancestry
+# imgadm import c8715b60-7e98-11ec-82d1-03d16599f529
+Importing c8715b60-7e98-11ec-82d1-03d16599f529 (base-64-lts@21.4.0) from "https://images.joyent.com"
+Gather image c8715b60-7e98-11ec-82d1-03d16599f529 ancestry
 Must download and install 1 image (148.6 MiB)
 Download 1 image     [=======================>] 100% 148.62MB 497.77KB/s  5m 5s
-Downloaded image c193a558-1d63-11e9-97cf-97bb3ee5c14f (148.6 MiB)
-...97cf-97bb3ee5c14f [=======================>] 100% 148.62MB   5.12MB/s    29s
-Imported image c193a558-1d63-11e9-97cf-97bb3ee5c14f (base-64-lts@18.4.0)
+Downloaded image c8715b60-7e98-11ec-82d1-03d16599f529 (148.6 MiB)
+...82d1-03d16599f529 [=======================>] 100% 148.62MB   5.12MB/s    29s
+Imported image c8715b60-7e98-11ec-82d1-03d16599f529 (base-64-lts@21.4.0)
 #
 ```
 
@@ -192,7 +192,7 @@ To create a zone, you need to create a `joyent` branded zone with
 `vmadm`. We recommend that the zone have the following attributes:
 
 * The brand set to `"joyent"`
-* The `image_uuid` set to `"c193a558-1d63-11e9-97cf-97bb3ee5c14f"`
+* The `image_uuid` set to `"c8715b60-7e98-11ec-82d1-03d16599f529"`
 * At least 25 GiB of disk space specified in the `quota` property
 * At least 2-4 GiB of DRAM specified in the `max-physical-memory`
 property
@@ -903,16 +903,16 @@ Running mount -O -F lofs -o ro /var/tmp/smartos-test-loopback/usr /usr
 Running tar -xzf ./tests-test_archive-master-20191001T134222Z.tgz -C / ./opt ./kernel ./tests.manifest.gen ./tests.buildstamp
 adding cyrus user
 adding ztest user
-Running curl -kO https://pkgsrc.joyent.com/packages/SmartOS/bootstrap/bootstrap-2018Q4-tools.tar.gz
+Running curl -kO https://pkgsrc.joyent.com/packages/SmartOS/bootstrap/bootstrap-2021Q4-tools.tar.gz
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100 22.9M  100 22.9M    0     0   566k      0  0:00:41  0:00:41 --:--:--  577k
-Running tar -zxpf bootstrap-2018Q4-tools.tar.gz -C /
+Running tar -zxpf bootstrap-2021Q4-tools.tar.gz -C /
 Running ln -s /opt/tools /opt/local
 Running pkgin -y in python27 sudo coreutils gcc7 gmake
 reading local summary...
 processing local summary...
-processing remote summary (https://pkgsrc.joyent.com/packages/SmartOS/2018Q4/tools/All)...
+processing remote summary (https://pkgsrc.joyent.com/packages/SmartOS/2021Q4/tools/All)...
 pkg_summary.xz                                                                                        100%  120KB 119.9KB/s   00:00
 calculating dependencies...done.
 

--- a/configure
+++ b/configure
@@ -483,14 +483,6 @@ done
 
 PRIMARY_COMPILER_VER=$(echo $PRIMARY_COMPILER | sed 's/^gcc//')
 
-# XXX KEBE SAYS POSSIBLY NUKE THIS WHOLE SECTION.
-# XXX KEBE SAYS BUT FOR NOW, JUST COMMENT IT OUT.
-# To allow building on base-64-lts 18.4 systems where
-# /opt/local/bin/gcc is incapable of building our local copy
-# of gcc 4, specify where to find gcc49 which gets installed
-# during 'install_pkgin'.
-#HOST_GCC4_PREFIX=/opt/local/gcc49/bin
-
 cat >build.env <<EOF
 FORCE_STRAP_REBUILD=$FORCE_STRAP_REBUILD
 ILLUMOS_CLOBBER=$ILLUMOS_CLOBBER

--- a/configure
+++ b/configure
@@ -203,7 +203,7 @@ function install_pkgin
 	pkglist="build-essential flex libxslt openjdk11 nodejs"
 	pkglist="$pkglist p5-XML-Parser gettext python27 py27-expat"
 	pkglist="$pkglist coreutils gsed pkg_alternatives cdrtools"
-	pkglist="$pkglist py27-sqlite3 nasm pigz gcc49 smartos-build-tools"
+	pkglist="$pkglist py27-sqlite3 nasm pigz smartos-build-tools"
 
 	$conf_priv pkgin -f update || fatal "failed to update pkgsrc repository"
 
@@ -438,8 +438,8 @@ read -r -d '' usage <<EOF
 		full strap build (no cache) [default: no]
 	-S
 		do *not* run smatch [default is to run smatch]
-	-s gcc4
-		shadow compilers, comma delimited (gcc4,gcc#) [default: none]
+	-s gcc10
+		shadow compilers, comma delimited (gcc10,gcc#) [default: none]
 EOF
 
 while getopts "cdhp:P:rSs:" arg; do
@@ -483,11 +483,13 @@ done
 
 PRIMARY_COMPILER_VER=$(echo $PRIMARY_COMPILER | sed 's/^gcc//')
 
+# XXX KEBE SAYS POSSIBLY NUKE THIS WHOLE SECTION.
+# XXX KEBE SAYS BUT FOR NOW, JUST COMMENT IT OUT.
 # To allow building on base-64-lts 18.4 systems where
 # /opt/local/bin/gcc is incapable of building our local copy
 # of gcc 4, specify where to find gcc49 which gets installed
 # during 'install_pkgin'.
-HOST_GCC4_PREFIX=/opt/local/gcc49/bin
+#HOST_GCC4_PREFIX=/opt/local/gcc49/bin
 
 cat >build.env <<EOF
 FORCE_STRAP_REBUILD=$FORCE_STRAP_REBUILD

--- a/docs/dev-upgrade.md
+++ b/docs/dev-upgrade.md
@@ -1,7 +1,7 @@
 # Upgrading Development Zones
 
 Over time, we update the base development environment that everyone is using.
-The current target is the x86_64 2018.4.x image series as noted in
+The current target is the x86_64 2021.4.x image series as noted in
 [the SmartOS Getting Started Guide](../README.md#importing-the-zone-image).
 
 The purpose of this guide is to describe how an **existing** development zone
@@ -80,11 +80,11 @@ In this case, we're interested in upgrading the instance called
 `march-dev`. Next we create a snapshot and verify it exists:
 
 ```
-$ triton inst snapshot create --name=2018.4-upgrade march-dev
-Creating snapshot 2018.4-upgrade of instance march-dev
+$ triton inst snapshot create --name=2021.4-upgrade march-dev
+Creating snapshot 2021.4-upgrade of instance march-dev
 $ triton inst snapshot list march-dev
 NAME            STATE    CREATED
-2018.4-upgrade  created  2018-09-28T18:40:14.000Z
+2021.4-upgrade  created  2018-09-28T18:40:14.000Z
 ```
 
 #### Manual Snapshots in SmartOS
@@ -97,8 +97,8 @@ Then you use the `create-snapshot` option.
 [root@00-0c-29-37-80-28 ~]# vmadm list
 UUID                                  TYPE  RAM      STATE             ALIAS
 79809c3b-6c21-4eee-ba85-b524bcecfdb8  OS    4096     running           multiarch
-[root@00-0c-29-37-80-28 ~]# vmadm create-snapshot 79809c3b-6c21-4eee-ba85-b524bcecfdb8 2018.4-upgrade
-Created snapshot 2018.4-upgrade for VM 79809c3b-6c21-4eee-ba85-b524bcecfdb8
+[root@00-0c-29-37-80-28 ~]# vmadm create-snapshot 79809c3b-6c21-4eee-ba85-b524bcecfdb8 2021.4-upgrade
+Created snapshot 2021.4-upgrade for VM 79809c3b-6c21-4eee-ba85-b524bcecfdb8
 ```
 
 If your VM has delegated snapshots, you won't be able to use `vmadm` to take

--- a/docs/dev-upgrade.md
+++ b/docs/dev-upgrade.md
@@ -340,10 +340,6 @@ $ ./configure && gmake live
 $
 ```
 
-Note that during the `configure` phase, if gcc49 does not exist on the
-system, it will be installed as it's still needed for bootstrapping the
-`proto.strap` gcc compiler used by the build.
-
 ## Cleaning Up
 
 Once you're satisfied, you should go through and delete the snapshots

--- a/src/Makefile
+++ b/src/Makefile
@@ -217,6 +217,7 @@ $(KSTAT.NODE) :	LIBS +=		-lkstat
 NODE_SUBDIR_ENV = \
 			V=1 \
 			NODE_DTRACE_PROVIDER_REQUIRE=hard \
+			PYTHON="/opt/local/bin/python2.7" \
 			CC="$(GCC)" \
 			CXX="$(GXX)" \
 			CPPFLAGS="$(NODE_CPPFLAGS)" \

--- a/tools/builder/Makefile
+++ b/tools/builder/Makefile
@@ -21,4 +21,4 @@ users.c:
 	./build_users_c.sh $(SRC_ROOT)/proto/ > users.c.tmp && mv users.c.tmp users.c
 
 clean:
-	rm -f $(TARGETS) $(OBJS)
+	rm -f $(TARGETS) $(OBJS) users.c

--- a/tools/builder/builder.c
+++ b/tools/builder/builder.c
@@ -111,6 +111,13 @@ void handle_file(const char *target, const char *mode, const char *user, const c
 
 }
 
+/* Disambiguate the chasing of symlinks at the end... */
+static int
+no_xpg4_link(const char *existing, const char *new)
+{
+	return (linkat(AT_FDCWD, existing, AT_FDCWD, new, 0));
+}
+
 void handle_link(const char *target, const char *type, int(*linker)(const char *, const char *))
 {
   char *copy, *ptr, *oldpath, *newpath;
@@ -234,7 +241,7 @@ int main(int argc, char *argv[])
            case 'h':
              if (args_found == 2) {
                if (pass == 4) {
-                 handle_link(target, "link", link);
+                 handle_link(target, "link", no_xpg4_link);
                }
              } else {
                printf("Wrong number of arguments for link on line[%d]: %s\n", lineno, line);

--- a/tools/builder/builder.c
+++ b/tools/builder/builder.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/fcntl.h>
 
 #define MAX_DIRS     10
 #define MAX_LINE_LEN 1024


### PR DESCRIPTION
This branch, and the one in joyent/illumos-extra, combine to allow SmartOS to get built in a 2021Q4 LTS base-64 pkgsrc image zone. As of the creation of this draft PR, It Builds (TM), but needs more testing, and lots of other things.