### PR TITLE
Add workaround for 90 second LX systemd stop/reboot delay

### DIFF
--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -17641,11 +17641,16 @@ function doShutdownStop(vmobj, options, callback)
                 cb();
             });
         }, function waitInstalled(cb) {
-            VM.waitForZoneState(vmobj, 'installed', {timeout: STOP_TIMEOUT},
-                function shutdownWaitCb(err) {
+            var stop_timeout = Date.now(0) + STOP_TIMEOUT * 1000;
+            var ival = setInterval(function () {
+                // Every second, tell `systemd-shutdown` to re-check
+                // its list of remaining processes.
+                // (By default, `systemd-shutdown` waits 90 seconds
+                // for a root cgroup SIGCHLD that is never sent.)
+                killSig(vmobj.pid, 'SIGCHLD');
 
-                if (err && err.hasOwnProperty('code')
-                    && err.code === 'ETIMEOUT') {
+                if (Date.now(0) > stop_timeout) {
+                    clearInterval(ival);
 
                     log.info('Timeout waiting for shutdown to complete; '
                         + 'halting.');
@@ -17660,10 +17665,22 @@ function doShutdownStop(vmobj, options, callback)
                             }
                             cb(_err);
                         });
-                    return;
                 }
-                cb(err);
-            });
+
+                var load_opts = {fields: ['zone_state'], log: log};
+                vmload.getVmobj(vmobj.uuid, load_opts, function (_err, vmobj) {
+                    if (_err) {
+                        log.warn({err: _err, stdout: fds.stdout,
+                            stderr: fds.stderr}, 'Error checking status while halting zone');
+                        return;
+                    }
+
+                    if (vmobj.zone_state == 'installed') {
+                        clearInterval(ival);
+                        cb();
+                    }
+                });
+            }, 1000);
         }, function zonecfgNoAutoboot(cb) {
             zonecfg(vmobj.uuid, [unset_autoboot], {log: log},
                 function (err, fds) {
@@ -18213,6 +18230,13 @@ function doReboot(vmobj, options, callback)
         }
         ticks = 180 * 10; // (180 * 10) 100ms ticks = 3m
         ival = setInterval(function () {
+            if (ticks % 10 == 0) {
+              // Every second, tell `systemd-shutdown` to re-check
+              // its list of remaining processes.
+              // (By default, `systemd-shutdown` waits 90 seconds
+              // for a root cgroup SIGCHLD that is never sent.)
+              killSig(vmobj.pid, 'SIGCHLD');
+            }
             if (reboot_complete) {
                 log.debug('reboot marked complete, cleaning up');
                 clearInterval(ival);


### PR DESCRIPTION
- When shutting down a SmartOS LX zone, `systemd-shutdown`'s `main()` calls `broadcast_signal()` first with SIGTERM, then with SIGKILL.
- At that point, the root cgroup becomes empty.
   - On recent real Linux kernels, systemd can use its "unified cgroup hierarchy" (cgroup-v2) codepath, [which signals when the cgroup becomes empty](https://github.com/systemd/systemd/blob/5645b4976ec35d24a341b6a7a3a7a205859e9864/src/core/cgroup.c#L3388), interrupting the `sigtimedwait()` and proceeding with the reboot without a delay.
   - On SmartOS LX, systemd uses its "legacy cgroup hierarchy" (cgroup-v1) codepath, [which _does not_ signal when the cgroup becomes empty](https://github.com/systemd/systemd/blob/5645b4976ec35d24a341b6a7a3a7a205859e9864/src/core/cgroup.c#L3412-L3413), so the `sigtimedwait()` continues until its 90 second timeout.

This PR modifies vmadm to send the `systemd-shutdown` process SIGCHLD periodically during a `vmadm stop` or `vmadm reboot` command, which causes `systemd-shutdown` to re-check its list of remaining processes, thereby removing the unnecessary delay.

Prior to this change, `vmadm stop` and `vmadm reboot` were taking slightly more than 90 seconds.  With this change, each takes about 10 seconds.

See discussion and @danmcd's initial testing on https://smartos.topicbox.com/groups/smartos-discuss/T7eaf4fad91e64ad8-M2e374d3cdfd9366191bc09b7.
