### PR TITLE
OS-8697 piadm's fatal() helper should echo all args

### DIFF
--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -14,6 +14,7 @@
 #
 # Copyright 2022 Joyent, Inc.
 # Copyright 2025 MNX Cloud, Inc.
+# Copyright 2025 Edgecast Cloud LLC.
 #
 
 # shellcheck disable=1091


### PR DESCRIPTION
Discovered when creating a boot pool and forgetting to supply `-B` 

`piadm` displayed a partial fatal message: `ERROR: Unusual configuration,`:

```
# piadm -v bootable -e -i latest bootpool
Version 1 of /var/piadm/piadm.conf
The following file contents have been configured:

PIADM_CONFIG_VERSION=1
PIADM_DIGEST_ALGORITHM=${PIADM_DIGEST_ALGORITHM:-md5}
PIADM_NO_SUM=${PIADM_NO_SUM:-0}

Downloading latest SmartOS ISO
################################################################################################################################################################################################################################################# 100.0%
published_checksum: a6e938a66e991db50c5530b67cab4c8c
local_checksum:     a6e938a66e991db50c5530b67cab4c8c
Installing PI 20251016T000143Z
Platform Image 20251016T000143Z will be loaded on next boot,

ERROR: Unusual configuration,

```


This should say: `ERROR: Unusual configuration, c0t5002538FC2B1A501d0s1 not ZFS`

This is due to the `fatal()` function only accepting one argument, but in two places the error message was split on two lines and sent to `fatal()` as two arguments:

```
fatal() {
        eecho
        if [[ -n "$1" ]]; then
                eecho "ERROR: $1"
        fi
        eecho
        exit 2
}
...
if [[ "$s1type" != "zfs" ]]; then
     fatal "Unusual configuration," \
             "${boot_devices[0]}s1 not ZFS"
fi
...
if [[ ! -d /${bootfs}/boot-${stamp} && "$iso" == "yes" ]]; then
        fatal "Installation problem (no ${bootfs}/boot-${stamp}" \
                "from ISO)"
fi
```


Testing notes (also on the Jira ticket):

Reproducer:

```
# zpool destroy bootpool

# zpool create -f bootpool mirror c0t5002538FC2B1A501d0 c0t5002538F3330AAE3d0

# piadm -v bootable -e -i /opt/smartos-latest.iso bootpool                 
Version 1 of /var/piadm/piadm.conf
The following file contents have been configured:

PIADM_CONFIG_VERSION=1
PIADM_DIGEST_ALGORITHM=${PIADM_DIGEST_ALGORITHM:-md5}
PIADM_NO_SUM=${PIADM_NO_SUM:-0}

Treating /opt/smartos-latest.iso as an ISO file.
Installing PI 20251016T000143Z
Platform Image 20251016T000143Z will be loaded on next boot,

ERROR: Unusual configuration,

```

After updating `fatal()` to echo `$@` instead of `$1`:

```
# zpool destroy bootpool                                                                                                                                                                                                                

# zpool create -f bootpool mirror c0t5002538FC2B1A501d0 c0t5002538F3330AAE3d0

# ./piadm -v bootable -e -i /opt/smartos-latest.iso bootpool                 
Version 1 of /var/piadm/piadm.conf
The following file contents have been configured:

PIADM_CONFIG_VERSION=1
PIADM_DIGEST_ALGORITHM=${PIADM_DIGEST_ALGORITHM:-md5}
PIADM_NO_SUM=${PIADM_NO_SUM:-0}

Treating /opt/smartos-latest.iso as an ISO file.
Installing PI 20251016T000143Z
Platform Image 20251016T000143Z will be loaded on next boot,

ERROR: Unusual configuration, c0t5002538FC2B1A501d0s1 not ZFS

```


And after creating the zpool properly with `-B`:

```
# zpool destroy bootpool                                                     

# zpool create -B -f bootpool mirror c0t5002538FC2B1A501d0 c0t5002538F3330AAE3d0

# ./piadm -v bootable -e -i /opt/smartos-latest.iso bootpool                    
Version 1 of /var/piadm/piadm.conf
The following file contents have been configured:

PIADM_CONFIG_VERSION=1
PIADM_DIGEST_ALGORITHM=${PIADM_DIGEST_ALGORITHM:-md5}
PIADM_NO_SUM=${PIADM_NO_SUM:-0}

Treating /opt/smartos-latest.iso as an ISO file.
Installing PI 20251016T000143Z
Platform Image 20251016T000143Z will be loaded on next boot,
    with a new boot image,
    boot image  20251016T000143Z
Removing old ./os/ directory
No need for the ./os/ directory, only one PI


```