### PR TITLE
TRITON-2520: Servers should not change UUID on reboot

### DIFF
--- a/src/sysinfo
+++ b/src/sysinfo
@@ -1191,6 +1191,8 @@ function valid_uuid(){
 # 3. org.smartos:server_uuid on $Zpool
 # We prefer 3 over 1
 # We prefer 2 over 3 and update 3 if they disagree.
+# NOTE: This function is only effective if called
+# AFTER both get_zpool and get_bootparams.
 function get_or_store_uuid()
 {
     [[ -z "$Zpool" ]] && return
@@ -1233,6 +1235,7 @@ if [[ ${ZONENAME} == "global" ]]; then
     get_disks
     get_recovery_configs
     get_bootparams
+    get_or_store_uuid
     get_psrinfo
     get_sdc_version
     if [[ -n ${SMARTDC_VERSION} ]]; then
@@ -1258,7 +1261,6 @@ get_smartos_vnics
 get_aggr_params
 get_boot_time
 get_dc_info
-get_or_store_uuid
 
 # whenever we update the cache, update both
 if [[ ${CACHE} == "true" ]]; then


### PR DESCRIPTION
```
Portions generated by: Claude <noreply@anthropic.com>
```

Code review of the current version by Claude:

```mermaid
flowchart TD
    Start([get_or_store_uuid called]) --> CheckZpool{Is $Zpool empty?}

    CheckZpool -->|Yes| Return([Return - do nothing])
    CheckZpool -->|No| GetSource[Get ZFS property source for<br/>org.smartos:server_uuid<br/>on $Zpool/var]

    GetSource --> CheckSource{Is source == 'local'?}

    CheckSource -->|No| NoStoredUUID[No stored UUID on pool]
    CheckSource -->|Yes| ReadStored[Read UUID value from pool]

    ReadStored --> CheckOverride{Is OVERRIDE_UUID set<br/>AND different from<br/>stored value?}

    CheckOverride -->|Yes| ValidateOverride{Is OVERRIDE_UUID<br/>a valid UUID?}
    CheckOverride -->|No| ValidateStored{Is stored UUID<br/>valid?}

    ValidateOverride -->|Yes| UpdatePool[Update pool with<br/>OVERRIDE_UUID]
    ValidateOverride -->|No| ValidateStored

    UpdatePool --> ReadBack[Read updated value<br/>back from pool]
    ReadBack --> ValidateStored

    ValidateStored -->|Yes| UseStored[Set UUID to stored value]
    ValidateStored -->|No| CleanupInvalid[Delete invalid UUID<br/>from pool using<br/>zfs inherit]

    UseStored --> End([Return])

    CleanupInvalid --> NoStoredUUID
    NoStoredUUID --> ValidateCurrent{Is current UUID<br/>valid?}

    ValidateCurrent -->|Yes| PersistUUID[Store current UUID<br/>on pool]
    ValidateCurrent -->|No| End

    PersistUUID --> End
```

## UUID Priority Order

The function implements the following priority for UUID sources:

1. **Highest Priority**: `override_uuid` bootparam (stored in `$OVERRIDE_UUID`)
   - If present, updates the pool and uses this value
2. **Second Priority**: `org.smartos:server_uuid` on `$Zpool/var`
   - Used if valid and no override is present
3. **Fallback**: `$UUID` from smbios
   - Used only if nothing valid is stored on pool

## Key Decision Points

- **Empty Zpool check**: Early exit if no pool is available
- **Source check**: Determines if a UUID has been previously stored
- **Override handling**: OVERRIDE_UUID takes precedence and updates pool if different
- **Validation**: All UUIDs are validated using `valid_uuid()` helper before use
- **Cleanup**: Invalid UUIDs are removed from pool to prevent corruption

## Side Effects

- May update `$UUID` global variable to the pool-stored value
- May write to ZFS pool property `org.smartos:server_uuid`
- May delete invalid pool property values