### PR TITLE
OS-8721 SmartOS builds in Jenkins should guarantee different buildstamps per stage

### DIFF
--- a/tools/build_jenkins
+++ b/tools/build_jenkins
@@ -8,6 +8,7 @@
 #
 # Copyright 2022 Joyent, Inc.
 # Copyright 2022 MNX Cloud, Inc.
+# Copyright 2026 Edgecast Cloud LLC.
 #
 
 #
@@ -27,9 +28,6 @@ set -o pipefail
 if [[ -z "${ENGBLD_DEST_OUT_PATH}" ]]; then
     export ENGBLD_DEST_OUT_PATH=/public/builds
 fi
-
-export TIMESTAMP=$(TZ=UTC /bin/date "+%Y%m%dT%H%M%SZ")
-export BUILDSTAMP=${TIMESTAMP}
 
 # Used to flag if this is a non-default build. This modifies the description
 # used for the platform manifest.
@@ -146,6 +144,33 @@ while getopts "cdhF:S:" opt; do
     esac
 done
 shift $((OPTIND - 1))
+
+# Set the timestamp now.
+export TIMESTAMP=$(TZ=UTC /bin/date "+%Y%m%dT%H%M%SZ")
+
+# And adjust the last digit (the 0-9 last "second") depending on our Jenkins
+# stage (to prevent BUILDSTAMP collisions in a given full Jenkins build).
+case "${JENKINS_BUILD_STAGE}" in
+    'default')
+        # Set to 7.
+	sed_string='s/[0-9]Z/7Z/'
+	;;
+    'debug')
+        # Set to 8.
+	sed_string='s/[0-9]Z/8Z/'
+	;;
+    'gcc14') # Update when alternate-compiler stage gets renamed/updated.
+        # Set to 9.
+	sed_string='s/[0-9]Z/9Z/'
+        ;;
+    *)
+        echo "Error: unknown Jenkins stage: ${JENKINS_BUILD_STAGE}"
+        usage
+esac
+
+# Finish adjustment and propagate it to the BUILDSTAMP.
+export TIMESTAMP=$(echo $TIMESTAMP | sed $sed_string)
+export BUILDSTAMP=${TIMESTAMP}
 
 if [[ -z "$PLATFORM_BUILD_FLAVOR" ]]; then
     PLATFORM_BUILD_FLAVOR="triton"

--- a/tools/build_jenkins
+++ b/tools/build_jenkins
@@ -145,6 +145,21 @@ while getopts "cdhF:S:" opt; do
 done
 shift $((OPTIND - 1))
 
+if [[ -z "$PLATFORM_BUILD_FLAVOR" ]]; then
+    PLATFORM_BUILD_FLAVOR="triton"
+fi
+
+case "${PLATFORM_BUILD_FLAVOR}" in
+    'triton'|'smartos'|'triton-and-smartos')
+        ;;
+    'strap-cache'|'ctftools'|'check')
+	NOSTAMP=yes
+	;;
+    *)
+        echo "Error: unknown platform build flavor: ${PLATFORM_BUILD_FLAVOR}"
+        usage
+esac
+
 # Set the timestamp now.
 export TIMESTAMP=$(TZ=UTC /bin/date "+%Y%m%dT%H%M%SZ")
 
@@ -164,25 +179,15 @@ case "${JENKINS_BUILD_STAGE}" in
 	sed_string='s/[0-9]Z/9Z/'
         ;;
     *)
-        echo "Error: unknown Jenkins stage: ${JENKINS_BUILD_STAGE}"
-        usage
+	if [[ -z "$NOSTAMP" ]]; then
+            echo "Error: unknown Jenkins stage: ${JENKINS_BUILD_STAGE}"
+            usage
+	fi
 esac
 
 # Finish adjustment and propagate it to the BUILDSTAMP.
 export TIMESTAMP=$(echo $TIMESTAMP | sed $sed_string)
 export BUILDSTAMP=${TIMESTAMP}
-
-if [[ -z "$PLATFORM_BUILD_FLAVOR" ]]; then
-    PLATFORM_BUILD_FLAVOR="triton"
-fi
-
-case "${PLATFORM_BUILD_FLAVOR}" in
-    'triton'|'smartos'|'triton-and-smartos'|'strap-cache'|'ctftools'|'check')
-        ;;
-    *)
-        echo "Error: unknown platform build flavor: ${PLATFORM_BUILD_FLAVOR}"
-        usage
-esac
 
 ENGBLD_LOGDIR=output/bits/platform${ENGBLD_DEBUG_SUFFIX}
 ENGBLD_LOG=${ENGBLD_LOGDIR}/build.log

--- a/tools/build_jenkins
+++ b/tools/build_jenkins
@@ -165,7 +165,7 @@ export TIMESTAMP=$(TZ=UTC /bin/date "+%Y%m%dT%H%M%SZ")
 
 # And adjust the last digit (the 0-9 last "second") depending on our Jenkins
 # stage (to prevent BUILDSTAMP collisions in a given full Jenkins build).
-case "${JENKINS_BUILD_STAGE}" in
+case "$JENKINS_STAGE_NAME" in
     'default')
         # Set to 7.
 	sed_string='s/[0-9]Z/7Z/'


### PR DESCRIPTION
First full build is running now.  Once I got over the stupid shell mistakes I made (variable name mismatch e.g.) things appear to be building.  The output stamps in manta's `platform{,-debug,-gcc14}` entries will be the {dis,}proof in the pudding.