### PR TITLE
OS-8724 - Reserve vendor-data for SmartOS/Triton use

### DIFF
--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -15690,7 +15690,9 @@ exports.start = function (uuid, extra, options, callback)
                 add_nics: hvmobj.nics || [],
                 resolvers: hvmobj.resolvers || [],
                 customer_metadata:
-                    hvmobj.customer_metadata || {}
+                    hvmobj.customer_metadata || {},
+                internal_metadata:
+                    hvmobj.internal_metadata || {}
             };
             var newHash = crypto.createHash('md5')
                 .update(JSON.stringify(cloudInitPayload))

--- a/src/vm/node_modules/cloudinit/nocloud.js
+++ b/src/vm/node_modules/cloudinit/nocloud.js
@@ -218,10 +218,10 @@ function userDataConfig(payload) {
 }
 
 function vendorDataConfig(payload) {
-    var customerMdata = payload.set_internal_metadata
+    var internalMdata = payload.set_internal_metadata
                         || payload.internal_metadata || {};
-    if (customerMdata.hasOwnProperty('cloud-init:vendor-data')) {
-        return customerMdata['cloud-init:vendor-data'];
+    if (internalMdata.hasOwnProperty('cloud-init:vendor-data')) {
+        return internalMdata['cloud-init:vendor-data'];
     }
     return undefined;
 }

--- a/src/vm/node_modules/cloudinit/nocloud.js
+++ b/src/vm/node_modules/cloudinit/nocloud.js
@@ -218,8 +218,8 @@ function userDataConfig(payload) {
 }
 
 function vendorDataConfig(payload) {
-    var customerMdata = payload.set_customer_metadata
-                        || payload.customer_metadata || {};
+    var customerMdata = payload.set_internal_metadata
+                        || payload.internal_metadata || {};
     if (customerMdata.hasOwnProperty('cloud-init:vendor-data')) {
         return customerMdata['cloud-init:vendor-data'];
     }

--- a/src/vm/tests/test-cloudinit-nocloud.js
+++ b/src/vm/tests/test-cloudinit-nocloud.js
@@ -640,7 +640,7 @@ test('_vendorDataConfig returns customer-provided vendor-data', function (t) {
     var customVendor = '#cloud-config\nruncmd:\n  - echo hello\n';
     var payload = {
         uuid: 'b4c7e1a2-3d5f-4e8a-9b0c-1d2e3f4a5b6c',
-        customer_metadata: {
+        internal_metadata: {
             'cloud-init:vendor-data': customVendor
         }
     };
@@ -661,22 +661,37 @@ test('_vendorDataConfig returns undefined when none provided', function (t) {
     t.end();
 });
 
-test('_vendorDataConfig prefers set_customer_metadata', function (t) {
+test('_vendorDataConfig ignores customer_metadata vendor-data', function (t) {
+    var customVendor = '#cloud-config\nruncmd:\n  - echo hello\n';
+    var payload = {
+        uuid: 'b4c7e1a2-3d5f-4e8a-9b0c-1d2e3f4a5b6c',
+        customer_metadata: {
+            'cloud-init:vendor-data': customVendor
+        }
+    };
+    var result = nocloud._vendorDataConfig(payload);
+
+    t.equal(result, undefined,
+        'vendor-data in customer_metadata is not used');
+    t.end();
+});
+
+test('_vendorDataConfig prefers set_internal_metadata', function (t) {
     var setVendor = '#cloud-config\nruncmd:\n  - echo set\n';
     var oldVendor = '#cloud-config\nruncmd:\n  - echo old\n';
     var payload = {
         uuid: 'b4c7e1a2-3d5f-4e8a-9b0c-1d2e3f4a5b6c',
-        set_customer_metadata: {
+        set_internal_metadata: {
             'cloud-init:vendor-data': setVendor
         },
-        customer_metadata: {
+        internal_metadata: {
             'cloud-init:vendor-data': oldVendor
         }
     };
     var result = nocloud._vendorDataConfig(payload);
 
     t.equal(result, setVendor,
-        'prefers set_customer_metadata for vendor-data');
+        'prefers set_internal_metadata for vendor-data');
     t.end();
 });
 


### PR DESCRIPTION
Pull vendor-data from internal_metadata instead of customer_metadata.

Cloud-init will merge user-data and vendor-data (if the latter exists) preferring user-data: so there is no need for users to set vendor-data in customer_metadata. Moving vendor-data to internal_metadata makes this explicit and reserved for future platform use.

Testing notes in ticket.