### PR TITLE
vmadm create: reject invalid brand cleanly (#1168)

### DIFF
--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -4692,6 +4692,9 @@ function fixPayloadMemory(payload, vmobj, log)
         brand = payload.brand;
     }
 
+    assert(BRAND_OPTIONS.hasOwnProperty(brand),
+        'fixPayloadMemory: unsupported brand: ' + brand);
+
     if (BRAND_OPTIONS[brand].features.default_memory_overhead
         && payload.hasOwnProperty('ram')
         && !payload.hasOwnProperty('max_physical_memory')) {
@@ -10072,6 +10075,18 @@ function normalizePayload(payload, vmobj, log, callback)
     if (payload.hasOwnProperty('quota') && payload.quota === undefined) {
         // when unsetting quota we set to 0
         payload.quota = 0;
+    }
+
+    /*
+     * Validate any explicit payload brand before applying defaults.
+     * applyZoneDefaults() and fixPayloadMemory() index into BRAND_OPTIONS[brand]
+     * unguarded, so an unknown brand crashes with a TypeError before reaching
+     * the existing check further down.
+     */
+    if (payload.hasOwnProperty('brand')
+        && !BRAND_OPTIONS.hasOwnProperty(payload.brand)) {
+        callback(new Error('Unsupported brand: ' + payload.brand));
+        return;
     }
 
     if (vmobj) {

--- a/src/vm/tests/test-create.js
+++ b/src/vm/tests/test-create.js
@@ -292,6 +292,27 @@ test('test create with invalid IP', function (t) {
     );
 });
 
+test('test create with invalid brand', function (t) {
+    var p = {
+        alias: 'test-create-' + process.pid,
+        autoboot: false,
+        brand: 'smartos',
+        do_not_inventory: true,
+        image_uuid: vmtest.CURRENT_SMARTOS_UUID,
+        max_physical_memory: 512,
+        quota: 10
+    };
+
+    VM.create(p, function (err) {
+        t.ok(err, 'VM.create returned an error');
+        if (err) {
+            t.ok(/[Uu]nsupported brand/.test(err.message),
+                'rejected unsupported brand cleanly: ' + err.message);
+        }
+        t.end();
+    });
+});
+
 test('test create with tags', function (t) {
 
     var p = JSON.parse(JSON.stringify(payload_with_tags));


### PR DESCRIPTION
Fixes #1168.

`normalizePayload()` runs `applyZoneDefaults()` (and `fixPayloadMemory()`) before the existing invalid-brand check. Both index `BRAND_OPTIONS[brand].features.*` unguarded, so an unsupported brand throws `TypeError: Cannot read property 'features' of undefined` and dumps core instead of returning the clean error path.

- Move the brand-existence check above the apply-defaults branch in `normalizePayload`. Explicit unsupported brands now return `Error: Unsupported brand: <name>` via callback. No-brand and valid-brand paths are unchanged.
- Add an `assert` in `fixPayloadMemory` so future call paths that skip upfront validation fail with a clear message rather than silently TypeError'ing on one of the ~9 unguarded `BRAND_OPTIONS[brand]` dereferences in this file.
- Regression test in `test-create.js` calls `VM.create({brand: "smartos", ...})` and asserts the callback gets `Unsupported brand`.