### PR TITLE
OS-8754 let Jenkinsfile skip stages in case of single-stage failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,6 @@ pipeline {
     options {
         buildDiscarder(logRotator(numToKeepStr: '30'))
         timestamps()
-        parallelsAlwaysFailFast()
     }
     // Don't assign a specific agent for the entire job, in order to better
     // share resources across jobs. Otherwise, we'd tie up an agent here for
@@ -94,6 +93,12 @@ pipeline {
                 '</ul></p>'
         )
         booleanParam(
+            name: 'FAIL_FAST',
+            defaultValue: true,
+            description: 'This parameter, if set, will cause any stage to ' +
+                'stop the other stages in mid-build.'
+        )
+        booleanParam(
             name: 'SKIP_DEFAULT',
             defaultValue: false,
             description: 'This parameter, if set, will skip the build of the ' +
@@ -159,7 +164,7 @@ set -o pipefail
                 always {
                     cleanWs cleanWhenSuccess: true,
                         cleanWhenFailure: false,
-                        cleanWhenAborted: true,
+                         cleanWhenAborted: true,
                         cleanWhenNotBuilt: true,
                         deleteDirs: true
                 }
@@ -167,6 +172,7 @@ set -o pipefail
         }
 	stage('build-variants') {
         parallel {
+            failFast ${FAIL_FAST}
             stage('default') {
                 agent {
                     // There seems to be a Jenkins bug where ${WORKSPACE} isn't

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -171,8 +171,8 @@ set -o pipefail
             }
         }
 	stage('build-variants') {
+        failFast ${FAIL_FAST}
         parallel {
-            failFast ${FAIL_FAST}
             stage('default') {
                 agent {
                     // There seems to be a Jenkins bug where ${WORKSPACE} isn't

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,19 +97,19 @@ pipeline {
             name: 'SKIP_DEFAULT',
             defaultValue: false,
             description: 'This parameter, if set, will skip the build of the ' +
-                'default stage (that's run in parallel).'
+                'default stage (which is run in parallel).'
         )
         booleanParam(
             name: 'SKIP_DEBUG',
             defaultValue: false,
             description: 'This parameter, if set, will skip the build of the ' +
-                'debug stage (that's run in parallel).'
+                'debug stage (which is run in parallel).'
         )
         booleanParam(
             name: 'SKIP_OTHER_COMPILER',
             defaultValue: false,
             description: 'This parameter, if set, will skip the build of the ' +
-                'alternate-compiler (gcc14) stage (that's run in parallel).'
+                'alternate-compiler (gcc14) stage (which is run in parallel).'
         )
         booleanParam(
             name: 'BUILD_STRAP_CACHE',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@
 /*
  * Copyright 2022 Joyent, Inc.
  * Copyright 2025 MNX Cloud, Inc.
+ * Copyright 2026 Edgecast Cloud LLC.
  */
 
 @Library('jenkins-joylib@v1.0.8') _
@@ -93,6 +94,24 @@ pipeline {
                 '</ul></p>'
         )
         booleanParam(
+            name: 'SKIP_DEFAULT',
+            defaultValue: false,
+            description: 'This parameter, if set, will skip the build of the ' +
+                'default stage (that's run in parallel).'
+        )
+        booleanParam(
+            name: 'SKIP_DEBUG',
+            defaultValue: false,
+            description: 'This parameter, if set, will skip the build of the ' +
+                'debug stage (that's run in parallel).'
+        )
+        booleanParam(
+            name: 'SKIP_OTHER_COMPILER',
+            defaultValue: false,
+            description: 'This parameter, if set, will skip the build of the ' +
+                'alternate-compiler (gcc14) stage (that's run in parallel).'
+        )
+        booleanParam(
             name: 'BUILD_STRAP_CACHE',
             defaultValue: false,
             description: 'This parameter declares whether to build and ' +
@@ -176,6 +195,7 @@ set -o pipefail
                             branch 'master'
                             triggeredBy cause: 'UserIdCause'
                         }
+                        environment name: 'SKIP_DEFAULT', value: 'false'
                         environment name: 'ONLY_BUILD_STRAP_CACHE', value: 'false'
                     }
                 }
@@ -225,6 +245,7 @@ export ENGBLD_BITS_UPLOAD_IMGAPI=true
                         // any stages which may duplicate the arguments they
                         // specified. The same goes for the rest of the pipeline
                         // stages.
+                        environment name: 'SKIP_DEBUG', value: 'false'
                         environment name: 'PLAT_CONFIGURE_ARGS', value: ''
                         environment name: 'ONLY_BUILD_STRAP_CACHE', value: 'false'
                     }
@@ -269,6 +290,7 @@ export PLAT_CONFIGURE_ARGS="-d $PLAT_CONFIGURE_ARGS"
                             branch 'master'
                             triggeredBy cause: 'UserIdCause'
                         }
+                        environment name: 'SKIP_OTHER_COMPILER', value: 'false'
                         environment name: 'PLAT_CONFIGURE_ARGS', value: ''
                         environment name: 'ONLY_BUILD_STRAP_CACHE', value: 'false'
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,7 @@ pipeline {
                 '</ul></p>'
         )
         booleanParam(
-            name: 'FAIL_FAST',
+            name: 'failFast',
             defaultValue: true,
             description: 'This parameter, if set, will cause any stage to ' +
                 'stop the other stages in mid-build.'
@@ -171,7 +171,6 @@ set -o pipefail
             }
         }
 	stage('build-variants') {
-        failFast ${FAIL_FAST}
         parallel {
             stage('default') {
                 agent {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -164,7 +164,7 @@ set -o pipefail
                 always {
                     cleanWs cleanWhenSuccess: true,
                         cleanWhenFailure: false,
-                         cleanWhenAborted: true,
+                        cleanWhenAborted: true,
                         cleanWhenNotBuilt: true,
                         deleteDirs: true
                 }


### PR DESCRIPTION
At the very least the skip-stage booleans work.  Running a "regular build" now to make sure default behavior continues to work.

Going to see if I can get failed-stage to not kill the whole `parallel` stage too.